### PR TITLE
Add ai-notes, agents, drafts workflow & smoke-check

### DIFF
--- a/.github/agents/zoolanding-config-platform-audit.agent.md
+++ b/.github/agents/zoolanding-config-platform-audit.agent.md
@@ -1,0 +1,86 @@
+---
+name: zoolanding-config-platform-audit
+description: 'Use when auditing a Zoolanding change that may span multiple repositories, contracts, or deployment surfaces. Focus on cross-repo config-platform consistency across frontend, authoring, runtime, image upload, analytics, quick stats, and deployment docs.'
+argument-hint: 'Diff, feature, contract change, or repos to audit'
+tools: [read, search, execute, todo]
+user-invocable: true
+handoffs:
+  - label: Check Release Readiness
+    agent: zoolanding-production-readiness
+    prompt: Use the audit findings above to assess release readiness and blockers.
+    send: false
+---
+
+You are a cross-repository audit agent for the Zoolanding config platform.
+
+Your job is to find contract drift, missing coordinated changes, and rollout risks when a change touches more than one part of the platform.
+
+## Scope
+
+Anchor the audit in these sources:
+
+- [Project Architecture](../../docs/02-architecture.md)
+- [API-Driven Configuration](../../docs/api-driven-config/README.md)
+- [Deployment Guide](../../docs/06-deployment.md)
+- [Draft Lifecycle](../../docs/11-draft-lifecycle.md)
+- [Public Assets And File Uploads](../../docs/12-public-assets-and-file-uploads.md)
+- [Zoolanding Frontend Workflow](../skills/zoolanding-frontend-workflow/SKILL.md)
+
+Also inspect the related repositories when the change touches their contracts:
+
+- `../zoolanding-config-authoring`
+- `../zoolanding-config-runtime-read`
+- `../zoolanding-image-upload`
+- `../zoolanding-data-dropper-lambda`
+- `../zoolanding-quick-stats-lambda`
+
+## Constraints
+
+- Do not implement fixes.
+- Do not focus on style-only issues.
+- Do not treat a single-repo pass as enough when the change clearly affects a shared contract.
+- If a repo was not checked but should have been, report that as a gap.
+
+## Audit Checklist
+
+1. Identify the changed contract surface.
+
+   - authored local files
+   - authoring transport
+   - runtime bundle transport
+   - uploaded public asset flow
+   - analytics or quick-stats behavior
+   - deployment or DNS/CDN routing assumptions
+
+2. Map the impacted repos.
+
+   - frontend rendering or bootstrap in `zoolandingpage`
+   - authoring actions and alias persistence
+   - runtime bundle resolution and merge order
+   - image upload request and `publicUrl` contract
+   - analytics or quick-stats endpoint behavior
+
+3. Look for drift.
+
+   - request/response shape mismatches
+   - stale docs or examples
+   - missing frontend gating such as analytics enablement
+   - alias, canonical, or managed-domain inconsistencies
+   - deployment sequencing or packaging assumptions that are no longer true
+
+4. Return the audit.
+   - findings first, ordered by severity
+   - impacted repos and files
+   - required coordinated changes
+   - smallest verification order across repos
+
+## Output Format
+
+Use this structure:
+
+1. `Findings`
+2. `Impacted Repos`
+3. `Required Coordinated Changes`
+4. `Verification Order`
+
+Be explicit when a change is safe in one repo but incomplete across the platform.

--- a/.github/agents/zoolanding-production-readiness.agent.md
+++ b/.github/agents/zoolanding-production-readiness.agent.md
@@ -1,0 +1,69 @@
+---
+name: zoolanding-production-readiness
+description: 'Use when reviewing a Zoolanding landing, draft, or platform change for release readiness, quality gates, missing validation, missing QA evidence, or publish blockers. Focus on findings first, not implementation.'
+argument-hint: 'Scope, domain, diff, or release candidate to assess'
+tools: [read, search, execute, todo]
+user-invocable: true
+---
+
+You are a release-readiness reviewer for the Zoolanding platform.
+
+Your job is to decide whether a change is ready to move from draft or implementation toward release, and to explain the blockers with concrete evidence.
+
+## Scope
+
+Ground your review in these sources first:
+
+- [Production Readiness And Quality Gates](../../ai-notes/constraints/production-readiness-and-quality-gates.md)
+- [Agent Task Workflow](../../ai-notes/notes/agent-task-workflow.md)
+- [Draft Lifecycle](../../docs/11-draft-lifecycle.md)
+- [Zoolanding Frontend Workflow](../skills/zoolanding-frontend-workflow/SKILL.md)
+
+When the request involves an existing local draft, also inspect the relevant committed note plus any local `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, and `drafts/{domain}/errors-reports/` material that applies before finalizing the verdict.
+
+## Constraints
+
+- Do not implement fixes.
+- Do not rewrite large areas of code or payloads.
+- Do not call something production-ready when evidence is missing.
+- If a required gate was not checked, report it as a blocker or gap instead of assuming a pass.
+
+## Approach
+
+1. Determine the review target.
+
+   - Identify the affected landing, repo area, or release candidate.
+   - Separate local draft state, authoring state, published runtime state, and deployment state.
+
+2. Check the minimum gates.
+
+   - business facts or approved intake
+   - structural payload or contract validation
+   - semantic completeness
+   - security gate status
+   - build and warning status
+   - deterministic tests
+   - manual desktop and mobile QA
+   - analytics, consent, and localization when relevant
+
+3. Inspect evidence.
+
+   - Read the relevant docs, notes, changed files, and tests.
+   - Run the narrowest useful commands when evidence is missing and the needed check is available.
+
+4. Return a release verdict.
+   - Findings first, ordered by severity.
+   - Then a clear verdict: ready, conditionally ready, or not ready.
+   - Then the exact remaining gates or blockers.
+   - Do not mark the target correct until the repo closeout rule has been satisfied: audit three times, and for draft-affecting work finish with browser QA in both desktop and mobile viewports.
+
+## Output Format
+
+Use this structure:
+
+1. `Findings`
+2. `Verdict`
+3. `Missing Evidence Or Remaining Gates`
+4. `Recommended Next Check`
+
+Keep summaries short. The findings are the primary output.

--- a/.github/instructions/triple-audit-closeout.instructions.md
+++ b/.github/instructions/triple-audit-closeout.instructions.md
@@ -1,0 +1,12 @@
+---
+applyTo: '**'
+description: 'Use for any Zoolandingpage task that will be declared correct or complete. Enforces triple-audit closeout and browser QA for draft-affecting work.'
+---
+
+Before declaring any Zoolandingpage task correct or complete:
+
+1. Audit the work, fix what you find, and rerun the audit at least three times.
+2. Do not treat automated checks alone as sufficient when draft behavior changed.
+3. If the task affects drafts, routes, payloads, rendering, or authoring workflow, finish with browser QA on every affected draft route in both desktop and mobile viewports.
+4. Correct any visible, runtime, console, network, or responsiveness issue found during that browser pass before closing the task.
+5. Distill reusable lessons into `ai-notes/` and keep draft-specific history local under `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, or `drafts/{domain}/errors-reports/`.

--- a/.github/prompts/draft-round-trip.prompt.md
+++ b/.github/prompts/draft-round-trip.prompt.md
@@ -1,0 +1,35 @@
+---
+name: 'Draft Round Trip'
+description: 'Plan or verify a Zoolanding draft pull, create, push, pack, unpack, or publish workflow. Use when syncing local draft files with the config authoring API or preparing a publish from zoolandingpage.'
+argument-hint: 'Domain, endpoint, or desired state transition'
+agent: 'agent'
+---
+
+Help with a draft round-trip in this repository.
+
+Follow [Zoolanding Frontend Workflow](../skills/zoolanding-frontend-workflow/SKILL.md) and these source docs:
+
+- [Draft Lifecycle](../../docs/11-draft-lifecycle.md)
+- [Deployment Guide](../../docs/06-deployment.md)
+- [Shared Draft Authoring Rules](../../ai-notes/knowledge/draft-authoring-rules.md)
+
+First distinguish which state the user is talking about:
+
+- local draft files
+- authoring draft state
+- published runtime state
+
+Then choose the narrowest needed operation: `pull`, `create`, `push`, `publish`, `pack`, or `unpack`.
+
+Prefer the direct CLI form `node tools/config-draft-sync.mjs ...` over wrapper scripts when showing commands.
+
+Use the user's arguments to determine the domain, endpoint, stage, and verification scope.
+
+Return:
+
+1. current state and target state
+2. exact commands to run or inspect
+3. blockers or risk first
+4. the verification step after the state change
+5. any doc updates needed if the workflow itself changed
+6. any remaining closeout work needed to satisfy the repo rule: triple audit plus desktop/mobile browser QA when the task affects draft behavior

--- a/.github/prompts/draft-smoke-check.prompt.md
+++ b/.github/prompts/draft-smoke-check.prompt.md
@@ -1,0 +1,30 @@
+---
+name: 'Draft Smoke Check'
+description: 'Validate Zoolanding local draft previews after frontend, payload, SSR, routing, or alias changes. Use when checking unresolved-draft failures, draft route rendering, or local-vs-live parity for managed aliases.'
+argument-hint: 'Local base URL, domain filter, or changed area'
+agent: 'agent'
+---
+
+Validate the affected draft preview in this repository.
+
+Follow [Zoolanding Frontend Workflow](../skills/zoolanding-frontend-workflow/SKILL.md) and the source workflow docs:
+
+- [Draft Lifecycle](../../docs/11-draft-lifecycle.md)
+- [Shared Draft Authoring Rules](../../ai-notes/knowledge/draft-authoring-rules.md)
+- [Repo Checklist](../skills/zoolanding-frontend-workflow/references/repo-checklist.md)
+
+Use the user's arguments to identify the local base URL, target domains, changed routes, or affected files.
+
+Prefer the smallest useful validation path:
+
+- use `node tools/draft-smoke-check.mjs --local-base-url=...` when multiple draft routes, managed aliases, or parity checks are involved
+- use a manual preview URL with `draftDomain` and `draftPageId` when a single draft or page is enough
+- add `--domain=` or `--output=` only when they materially reduce noise or preserve evidence
+
+Return:
+
+1. the validation scope
+2. the exact command(s) or preview URL(s)
+3. findings or blockers first
+4. the next verification step if anything remains unproven
+5. whether desktop and mobile browser QA is still pending before closeout

--- a/.github/skills/zoolanding-frontend-workflow/SKILL.md
+++ b/.github/skills/zoolanding-frontend-workflow/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: zoolanding-frontend-workflow
+description: 'Zoolanding Angular frontend workflow for SSR, draft preview, config-driven landing pages, authoring round-trips, and platform documentation updates. Use when changing Angular app code, draft payload behavior, runtime integration, analytics, quick stats, or local authoring tools in zoolandingpage.'
+user-invocable: true
+---
+
+# Zoolanding Frontend Workflow
+
+Use this skill for work inside the Angular app and its platform-facing docs.
+
+## What Matters In This Repo
+
+- This repo is the main source of truth for cross-platform behavior in the Zoolanding stack.
+- Most mistakes come from confusing local draft files, authoring draft state, and published runtime state.
+- Frontend changes often need matching documentation updates when payloads, endpoints, or workflows change.
+
+## Workflow
+
+1. Read the repo memory first.
+
+   - Read `Codex.md`.
+   - Read `ai-notes/README.md`.
+   - Read the relevant committed note before editing.
+   - Inspect `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, and `drafts/{domain}/errors-reports/` when the task depends on an existing local draft.
+
+2. Identify which config state is involved.
+
+   - `drafts/{domain}/...` means local draft source.
+   - `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, and `drafts/{domain}/errors-reports/` mean local draft-specific history, investigation, or incident tracking.
+   - authoring API means stored draft state.
+   - runtime API means published live state.
+
+3. Find the narrowest affected surface.
+
+   - Angular UI and SSR behavior under `src/`
+   - draft payload structure under `drafts/`
+   - authoring or sync tooling under `tools/`
+   - platform docs under `docs/`
+
+4. Match existing platform conventions.
+
+   - Reuse current runtime/config service boundaries in `src/app/shared/services/`.
+   - Prefer the direct CLI form `node tools/config-draft-sync.mjs ...` when documenting authoring flows.
+   - Keep platform behavior explanations in this repo when the change affects other services.
+
+5. Verify with the smallest useful check.
+
+   - Use the Docker tasks already defined for lint and tests when code changes affect Angular behavior.
+   - Use the draft smoke check when route rendering, aliases, or draft payloads are involved.
+   - Use focused manual preview URLs when a full automation path is unnecessary.
+   - Before closing draft-affecting work, audit the change three times and run browser QA on every affected draft route in both desktop and mobile viewports.
+
+6. Update docs in the same change when needed.
+   - If payloads, workflows, endpoints, or platform interactions change, update the relevant docs.
+   - If the work produced reusable guidance, update `ai-notes/` before closing the task and keep draft-specific detail local under `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, or `drafts/{domain}/errors-reports/`.
+
+## Verification Heuristics
+
+- SSR or host-sensitive changes: verify allowed hosts and a real draft URL.
+- Draft/runtime bootstrap changes: verify the correct state source is being loaded.
+- Analytics or quick-stats changes: verify frontend config gates still control network behavior.
+- Tooling changes: verify the direct `node tools/config-draft-sync.mjs ...` path still works as documented.
+
+## Resources
+
+- [Repo Checklist](./references/repo-checklist.md)
+- [Canonical AI Notes](../../../ai-notes/README.md)

--- a/.github/skills/zoolanding-frontend-workflow/references/repo-checklist.md
+++ b/.github/skills/zoolanding-frontend-workflow/references/repo-checklist.md
@@ -1,0 +1,26 @@
+# Repo Checklist
+
+## Primary Areas
+
+- `Codex.md` and `ai-notes/` for canonical repo memory and durable workflow guidance
+- `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, and `drafts/{domain}/errors-reports/` for local draft-specific context when it exists
+- `src/app/shared/services/` for runtime, analytics, quick stats, and SEO boundaries
+- `drafts/` for local draft source files
+- `tools/config-draft-sync.mjs` for pack, pull, push, create, and publish flows
+- `docs/` for platform-level behavior and contributor guidance
+
+## Typical Checks
+
+- Read the relevant AI notes before changing payloads, workflow docs, or runtime behavior.
+- Run the relevant Docker lint or test task when Angular code changes.
+- Use a draft preview URL with `draftDomain` and `draftPageId` when validating runtime resolution.
+- Use `node tools/draft-smoke-check.mjs --local-base-url=http://127.0.0.1:4200` when draft routes or aliases change.
+- Before closing a draft-affecting task, audit it three times and run browser QA in desktop and mobile viewports on every affected draft route.
+- Keep docs aligned when endpoint behavior, payload contracts, or workflows move.
+- Distill durable findings back into `ai-notes/` before closing the task.
+
+## Common Pitfalls
+
+- Mixing local draft state with authoring or published runtime state.
+- Documenting CLI wrappers when the direct Node command is clearer.
+- Changing cross-platform behavior in code without updating the main platform docs.

--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,6 @@ Thumbs.db
 .env
 
 # Local drafts (API emulation)
-/public/assets/drafts/
-/devonly/*
+/drafts/*
+!/drafts/.gitignore
+/devonly/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Zoolandingpage Agent Workflow
+
+Use this file as the repo-level entrypoint for future AI agents and new contributors.
+
+## Read Order Before Editing
+
+1. Read [Codex.md](./Codex.md).
+2. Read [ai-notes/README.md](./ai-notes/README.md).
+3. Read the most relevant committed note under [ai-notes/](./ai-notes/).
+4. If the task touches an existing local draft, inspect `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, and `drafts/{domain}/errors-reports/` when those folders exist.
+5. Read the implementation docs that match the task, especially under [docs/](./docs/).
+
+## Working Rules
+
+- Treat `drafts/` as the local draft source tree and local draft-specific scratch workspace.
+- Treat `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, and `drafts/{domain}/errors-reports/` as local-only historical, investigative, or incident material, not as canonical committed guidance.
+- Treat [ai-notes/](./ai-notes/) as the shared, curated, long-lived knowledge base for reusable workflow guidance.
+- Treat `devonly/` only as optional local-only untracked scratch if you need repo-level temporary investigation space.
+- During work, update committed notes only when the lesson is reusable beyond one draft. Use the templates in [ai-notes/templates/](./ai-notes/templates/) instead of inventing new note shapes.
+- After finishing work, distill reusable learnings back into the canonical folder and keep draft-specific detail in `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, or `drafts/{domain}/errors-reports/`.
+- Keep note timestamps in Central Time.
+
+## Closeout Mantra
+
+- Before declaring a task correct, audit it, fix what you find, and rerun the audit at least three times.
+- For draft-affecting work, finish with browser QA on every affected draft route in both desktop and mobile viewports and correct any issue found there before closing.
+
+## Safety And Security Rules
+
+- Do not store secrets, credentials, tokens, raw environment-variable values, signed URLs, private customer data, or other PII in any note.
+- If a workflow depends on sensitive data, describe the dependency abstractly instead of copying the sensitive detail into committed notes.
+- If code or runtime behavior disagrees with a note, do not guess. Record the mismatch and update the reusable note after verification.
+
+## Update Triggers
+
+Update the canonical shared notes when you:
+
+- discover a reusable visual-parity rule or authoring constraint
+- find a routing, slug, embed, or Angora limitation that will affect future work
+- identify a durable QA, release, or authoring workflow improvement
+- extract a reusable rule from one draft that future drafts should inherit

--- a/Codex.md
+++ b/Codex.md
@@ -1,0 +1,48 @@
+# Zoolandingpage Codex Memory
+
+## Canonical Paths
+
+- Local draft source and scratch workspace: `drafts/`
+- Local draft-specific notes: `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, and `drafts/{domain}/errors-reports/`
+- Curated AI/developer guidance: [ai-notes/README.md](./ai-notes/README.md)
+- Committed reusable rules and procedures: [ai-notes/](./ai-notes/)
+- Note templates: [ai-notes/templates/](./ai-notes/templates/)
+- Optional local-only scratch: `devonly/`
+- Main implementation docs: `docs/`
+
+## Current Decisions
+
+- `drafts/` is the local authored draft tree and local per-draft scratch area.
+- `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, and `drafts/{domain}/errors-reports/` are local-only and should not be treated as committed source of truth.
+- `devonly/` is optional local-only untracked scratch if repo-level temporary investigation space is needed.
+- `ai-notes/` is the curated, shared-first knowledge base that future agents and developers must read before new work.
+- `AGENTS.md` plus this file are the repo-level agent hooks for v1.
+- Notes should stay English-first to match repo documentation, while quoted source content may stay in its original language.
+- Note headers should always include `Date`, `Scope`, `Status`, `Applies To`, `Source Of Truth`, `Confidence`, and `Last Reviewed`.
+- Use Central Time for note dates and reviews.
+
+## Naming Rules
+
+- Iteration logs: `YYYY-MM-DD-topic.md`
+- Visual baselines: `{page}-visual-baseline.md`
+- General note filenames: kebab-case
+- Use the existing templates before creating a new note type
+
+## Closeout Checklist
+
+Before ending a task:
+
+1. Confirm the relevant shared notes were read first and inspect local draft notes when the task depends on an existing draft.
+2. Update the canonical notes only if the task produced reusable guidance beyond one draft.
+3. Keep draft-specific scratch notes in `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, or `drafts/{domain}/errors-reports/`.
+4. Keep repo-level scratch or operational notes local-only if you need them; do not make them part of the committed canonical tree.
+5. Remove or avoid any secrets, credentials, raw env values, signed URLs, or PII from the notes.
+6. Update repo docs if the workflow changed.
+7. Audit, fix, and rerun the audit at least three times before calling the work correct.
+8. If draft behavior changed, finish with browser QA on every affected draft route in desktop and mobile viewports.
+
+## Guardrails
+
+- If notes and code disagree, verify against code and docs, then repair the notes.
+- Do not let one-off debugging output become canonical guidance without distillation.
+- Keep canonical notes focused on reusable decisions, constraints, QA rules, and workflows.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Zoolandingpage is the Angular frontend for a config-driven landing page platform.
 
-In local development, the app renders draft JSON from `public/assets/drafts`. In production, it renders a published runtime bundle returned by the config runtime API. The same platform also integrates with a config authoring API, a public asset upload API, a raw analytics collector, and a quick-stats service.
+In local development, the app renders draft JSON from the repo-root `drafts/` tree, served at `/drafts/...`. In production, it renders a published runtime bundle returned by the config runtime API. The same platform also integrates with a config authoring API, a public asset upload API, a raw analytics collector, and a quick-stats service.
 
 ## What this repository owns
 
@@ -25,7 +25,7 @@ In local development, the app renders draft JSON from `public/assets/drafts`. In
 
 These three states are the most important concept for new contributors:
 
-1. `Local draft files`: JSON files under `public/assets/drafts/{domain}/...` that you edit in the repo.
+1. `Local draft files`: JSON files under `drafts/{domain}/...` that you edit in the repo.
 2. `Authoring draft state`: the draft currently stored in the config authoring API.
 3. `Published runtime state`: the version the runtime API returns to live sites.
 
@@ -54,6 +54,8 @@ http://127.0.0.1:4200/?draftDomain=test.zoolandingpage.com.mx&draftPageId=defaul
 
 If your dev server is exposed on another port through Docker, keep the same query parameters and switch only the host/port.
 
+Draft-specific scratch material now lives beside the payloads under `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, and `drafts/{domain}/errors-reports/`. Reusable guidance belongs in `ai-notes/`.
+
 ## Core workflows
 
 ### Inspect the draft CLI
@@ -73,6 +75,30 @@ Supported commands today:
 - `create`
 - `publish`
 
+### Smoke-check local drafts against live aliases
+
+When a local dev server is already running, you can run the browser-based draft smoke check:
+
+```bash
+node tools/draft-smoke-check.mjs --local-base-url=http://127.0.0.1:4200
+```
+
+Or use the package script:
+
+```bash
+npm run drafts:smoke -- --local-base-url=http://127.0.0.1:4200
+```
+
+What it checks:
+
+- every local draft route renders a title and a first heading
+- the page does not fall into the `Unresolved draft` fallback
+- any draft with a managed `*.zoolandingpage.com.mx` alias matches its live counterpart for title, first heading, and key header controls
+
+If you save the structured report with `--output=...`, each route now includes both desktop and mobile viewport results.
+
+If Chromium is not installed in a default location, pass `--browser-path=...`.
+
 The package scripts in `package.json` wrap the same commands, but the direct `node tools/config-draft-sync.mjs ...` form is the clearest option when you need explicit arguments.
 
 ### Typical round-trip
@@ -82,6 +108,8 @@ node tools/config-draft-sync.mjs pull --endpoint=https://api.zoolandingpage.com.
 node tools/config-draft-sync.mjs push --endpoint=https://api.zoolandingpage.com.mx/config-authoring --domain=zoolandingpage.com.mx --updated-by="Your Name"
 node tools/config-draft-sync.mjs publish --endpoint=https://api.zoolandingpage.com.mx/config-authoring --domain=zoolandingpage.com.mx --updated-by="Your Name"
 ```
+
+If the custom domain `https://api.zoolandingpage.com.mx/config-authoring` resets the connection during publish, retry through the raw API Gateway authoring endpoint documented in [docs/06-deployment.md](docs/06-deployment.md) to separate front-door transport problems from authoring-Lambda problems.
 
 For the full workflow, read [docs/11-draft-lifecycle.md](docs/11-draft-lifecycle.md).
 
@@ -100,12 +128,13 @@ For the current request shape, upload sequence, and how to reference the returne
 Start here in this order:
 
 1. [docs/DEVELOPER_ONBOARDING.md](docs/DEVELOPER_ONBOARDING.md)
-2. [docs/02-architecture.md](docs/02-architecture.md)
-3. [docs/03-development-guide.md](docs/03-development-guide.md)
-4. [docs/11-draft-lifecycle.md](docs/11-draft-lifecycle.md)
-5. [docs/12-public-assets-and-file-uploads.md](docs/12-public-assets-and-file-uploads.md)
-6. [docs/api-driven-config/README.md](docs/api-driven-config/README.md)
-7. [docs/06-deployment.md](docs/06-deployment.md)
+2. [ai-notes/README.md](ai-notes/README.md)
+3. [docs/02-architecture.md](docs/02-architecture.md)
+4. [docs/03-development-guide.md](docs/03-development-guide.md)
+5. [docs/11-draft-lifecycle.md](docs/11-draft-lifecycle.md)
+6. [docs/12-public-assets-and-file-uploads.md](docs/12-public-assets-and-file-uploads.md)
+7. [docs/api-driven-config/README.md](docs/api-driven-config/README.md)
+8. [docs/06-deployment.md](docs/06-deployment.md)
 
 Specialized references:
 
@@ -117,7 +146,11 @@ Specialized references:
 ## Important folders
 
 ```text
-public/assets/drafts/               Local draft source of truth for development
+drafts/                            Local draft source of truth for development
+drafts/{domain}/ai_notes/          Local draft-specific notes and historical context
+drafts/{domain}/findings/          Local draft-specific findings and investigation
+drafts/{domain}/errors-reports/    Local draft-specific incident notes when needed
+ai-notes/                          Canonical reusable workflow and knowledge base
 src/app/shared/services/            Config, analytics, SEO, and runtime services
 src/app/shared/types/               Payload contracts used by the frontend runtime
 tools/config-draft-sync.mjs         Local CLI for pack/pull/push/create/publish
@@ -139,7 +172,7 @@ Related platform repos used by this frontend:
 
 ## Contributing
 
-When you update payloads, workflows, or endpoint behavior, update documentation in the same change. The main repo should remain the source of truth for platform-level behavior; the Lambda repos should stay focused on their own contracts and deployment details.
+When you update payloads, workflows, or endpoint behavior, update documentation in the same change. Start with [ai-notes/README.md](ai-notes/README.md) plus the relevant committed note before new work, inspect local `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, and `drafts/{domain}/errors-reports/` when a task depends on an existing draft, and distill only reusable learnings back into the canonical folder before closing the task. Finish draft-affecting work with three audit passes and browser QA in desktop and mobile viewports. The main repo should remain the source of truth for platform-level behavior; the Lambda repos should stay focused on their own contracts and deployment details.
 
 ## License
 

--- a/ai-notes/README.md
+++ b/ai-notes/README.md
@@ -1,0 +1,105 @@
+# ai-notes
+
+Date: 2026-04-20 (Central Time)
+Scope: Canonical long-lived AI and developer guidance for Zoolandingpage.
+Status: Active
+Applies To: Reusable workflow, authoring, QA, operations, and release guidance
+Source Of Truth:
+
+- `AGENTS.md`
+- `Codex.md`
+- `docs/DEVELOPER_ONBOARDING.md`
+- `docs/03-development-guide.md`
+- `docs/11-draft-lifecycle.md`
+- Distilled knowledge from local `drafts/{domain}/ai_notes/**`, `drafts/{domain}/findings/**`, and `drafts/{domain}/errors-reports/**`
+- Sanitized operational lessons promoted from local-only recovery work
+
+Confidence: High
+Last Reviewed: 2026-04-20 (Central Time)
+
+This folder is the canonical home for reusable guidance that should survive beyond one task or one chat.
+
+## Read This Folder In This Order
+
+1. Read [../Codex.md](../Codex.md).
+2. Read [notes/agent-task-workflow.md](./notes/agent-task-workflow.md).
+3. Read the most relevant file under [knowledge/](./knowledge/), [constraints/](./constraints/), [how-to/](./how-to/), [future-features-ideas/](./future-features-ideas/), or [error-reports/](./error-reports/).
+4. If the task depends on an existing local draft, inspect `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, and `drafts/{domain}/errors-reports/` when those folders exist.
+5. Use the templates in [templates/](./templates/) when creating new committed notes.
+
+## What Belongs Here
+
+- reusable draft-authoring rules and evergreen platform knowledge
+- verified routing, slug, layout, embed, and readiness constraints
+- repeatable procedures and checklists that future contributors should follow
+- backlog-grade product or workflow ideas that help future planning
+- sanitized incident reports that preserve reusable lessons without exposing sensitive specifics
+- repo-level workflow and migration notes that future agents should understand
+
+## What Does Not Belong Here
+
+- draft-specific histories that matter only to one domain or one pass
+- raw debugging transcripts, terminal dumps, or ad hoc browser observations
+- secrets, credentials, tokens, raw env values, signed URLs, or PII
+- volatile infrastructure identifiers that are only useful during one live incident
+
+Keep draft-specific history in local `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, or `drafts/{domain}/errors-reports/`. If repo-level local-only scratch is ever needed again, keep it untracked under `devonly/`.
+
+## Folder Map
+
+- [notes/](./notes/): Canonical meta, workflow, and migration material
+- [knowledge/](./knowledge/): Evergreen distilled reference and reusable operational knowledge
+- [constraints/](./constraints/): Verified limitations, release gates, and durable rules
+- [how-to/](./how-to/): Repeatable procedures, checklists, and operating playbooks
+- [future-features-ideas/](./future-features-ideas/): Durable backlog-grade ideas discovered during work
+- [error-reports/](./error-reports/): Sanitized incident write-ups with reusable lessons
+- [templates/](./templates/): Standard note shapes for future committed notes
+
+## Taxonomy Rules
+
+- Use `knowledge/` for evergreen distilled reference that should stay true after the original task is forgotten.
+- Use `notes/` for canonical workflow, governance, or migration context about how this repository is operated.
+- Use `constraints/` when the main value is a verified limit, guardrail, or release gate.
+- Use `how-to/` when the main value is a repeatable procedure or checklist.
+- Use `future-features-ideas/` only for durable ideas worth revisiting later.
+- Use `error-reports/` for sanitized incidents that teach a reusable lesson.
+
+## Naming Rules
+
+- Root folder name: `ai-notes`
+- General filenames: kebab-case
+- Use the existing templates before inventing a new note shape
+
+## Standard Header
+
+Every note in this folder should start with:
+
+- `Date`
+- `Scope`
+- `Status`
+- `Applies To`
+- `Source Of Truth`
+- `Confidence`
+- `Last Reviewed`
+
+Dates should be written in Central Time.
+
+## When To Create Or Update A Note
+
+Create or update a committed note when:
+
+- a reusable authoring rule or limitation is discovered
+- a routing, alias, or slug decision becomes durable across drafts
+- a third-party embed or asset workflow needs repeatable handling
+- a QA, release, or browser-validation rule becomes reusable
+- a local draft uncovers a lesson future agents should not have to rediscover
+- an incident produces a reusable operations or recovery lesson
+- a feature request turns into a durable shared backlog idea
+
+If the learning matters only to one draft, keep it local and distill only the reusable part here.
+
+## Security Rules
+
+- Never store secrets, tokens, credentials, raw env values, signed URLs, or PII in these notes.
+- Summarize sensitive dependencies abstractly and point to durable docs instead of copying operational specifics.
+- Do not promote raw incident artifacts into this folder; sanitize them first.

--- a/ai-notes/constraints/angora-layout-constraints.md
+++ b/ai-notes/constraints/angora-layout-constraints.md
@@ -1,0 +1,30 @@
+# Angora Layout Constraints
+
+Date: 2026-04-19 (Central Time)
+Scope: Shared constraints and preferred patterns for Angora-based layout authoring.
+Status: Active
+Applies To: Config-authored layout work using Angora CSS
+Source Of Truth:
+
+- `docs/03-development-guide.md`
+- Promoted from local draft notes and findings
+
+Confidence: Medium to high
+Last Reviewed: 2026-04-19 (Central Time)
+
+## Preferred Authoring Pattern
+
+- Build section layout with explicit containers.
+- Keep headings, body copy, and CTA rows separate when exact placement matters.
+- Prefer shared-shell fixes before over-tuning individual sections.
+
+## Practical Rules
+
+- Use wrapper rows for centered actions instead of relying on auto margins.
+- When link labels must inherit a color reliably, set the text color on the wrapper or container if the component inherits `color`.
+- Prefer raw structural utility classes when combo expansion is unreliable for layout-critical behavior.
+
+## Validation Caveats
+
+- Integrated-browser width or stylesheet generation may not fully reflect the real local-browser result.
+- If a breakpoint or utility-token workaround becomes part of the durable solution, record it in a local constraint note or distill the reusable part here.

--- a/ai-notes/constraints/embeds-and-third-party-surfaces.md
+++ b/ai-notes/constraints/embeds-and-third-party-surfaces.md
@@ -1,0 +1,30 @@
+# Embeds And Third-Party Surfaces
+
+Date: 2026-04-19 (Central Time)
+Scope: Shared rules for drafts that depend on embeds or third-party visual surfaces.
+Status: Active
+Applies To: Embedded forms, maps, videos, documents, and other third-party surfaces
+Source Of Truth:
+
+- `docs/03-development-guide.md`
+- `docs/11-draft-lifecycle.md`
+- Promoted from local draft notes and findings
+
+Confidence: High
+Last Reviewed: 2026-04-19 (Central Time)
+
+## Composition Rules
+
+- Style the surrounding composition first: heading alignment, lead width, outer spacing, container width, and placement.
+- Treat the embedded provider surface as the visible card or media block when that matches the live reference.
+- Avoid adding extra wrapper cards or duplicate CTAs unless the source reference clearly needs them.
+
+## Validation Rules
+
+- Judge iframe-based surfaces by outer placement and visible first-screen behavior.
+- Do not promise precise parity for provider-owned internals that the draft system does not control.
+- Record any host-level styling limitation as a reusable future idea instead of hiding it in a one-off task log.
+
+## Known Durable Limitation
+
+- Leaf components such as `embed-frame` may need host-level classes or styles in future platform work when payload authors need stronger outer-width control.

--- a/ai-notes/constraints/production-readiness-and-quality-gates.md
+++ b/ai-notes/constraints/production-readiness-and-quality-gates.md
@@ -1,0 +1,42 @@
+# Production Readiness And Quality Gates
+
+Date: 2026-04-19 (Central Time)
+Scope: Shared release-readiness and quality-gate expectations for AI-authored landings.
+Status: Active
+Applies To: All draft-to-release workflows
+Source Of Truth:
+
+- `docs/11-draft-lifecycle.md`
+- `.github/skills/zoolanding-frontend-workflow/references/repo-checklist.md`
+- Promoted from local draft findings
+
+Confidence: High
+Last Reviewed: 2026-04-19 (Central Time)
+
+## Minimum Gates
+
+Before calling a landing production-ready, confirm:
+
+1. approved intake and business facts
+2. structural payload validation
+3. semantic completeness review
+4. security gate status
+5. build status and warning triage
+6. deterministic test status
+7. manual desktop and mobile QA
+8. analytics and consent verification
+9. localization review where applicable
+10. release verdict recorded in a readiness note
+
+## Common Blockers
+
+- placeholder business facts or unapproved legal copy
+- unresolved dependency vulnerabilities
+- unstable test exits despite passing assertions
+- build warnings that lower production confidence
+- missing lint or smoke-test coverage
+- no manual QA evidence
+
+## Reusable Rule
+
+A payload can be structurally valid and still fail release readiness. Keep readiness notes separate from payload-generation notes so future agents do not confuse "draft works" with "safe to publish."

--- a/ai-notes/constraints/routing-and-slug-rules.md
+++ b/ai-notes/constraints/routing-and-slug-rules.md
@@ -1,0 +1,37 @@
+# Routing And Slug Rules
+
+Date: 2026-04-19 (Central Time)
+Scope: Shared rules for authored paths, aliases, and draft-safe route ids.
+Status: Active
+Applies To: Local draft routing and multi-page draft work
+Source Of Truth:
+
+- `docs/11-draft-lifecycle.md`
+- `docs/DEVELOPER_ONBOARDING.md`
+- Promoted from local draft notes and findings
+
+Confidence: High
+Last Reviewed: 2026-04-19 (Central Time)
+
+## Preview Rules
+
+- Use `draftDomain` and `draftPageId` in local preview URLs so draft resolution stays explicit.
+- Do not embed those query parameters into authored navigation links.
+
+## Authored Route Rules
+
+- Prefer safe internal route ids such as `contact` over accented or fragile ids inside payloads.
+- Preserve live-like routes through aliases or route metadata when the public site needs them.
+- Keep folder names, payload domain values, aliases, and canonical origins aligned.
+
+## Drift Checks
+
+When a route behaves strangely, verify:
+
+1. draft folder name
+2. payload `domain` values
+3. authored links
+4. local preview query parameters
+5. alias and canonical config
+
+Record any durable mismatch in a local note or distill the reusable rule here.

--- a/ai-notes/error-reports/shared-edge-origin-drift-recovery-pattern.md
+++ b/ai-notes/error-reports/shared-edge-origin-drift-recovery-pattern.md
@@ -1,0 +1,50 @@
+# Shared Edge Origin Drift Recovery Pattern
+
+Date: 2026-04-20 (Central Time)
+Scope: Sanitized reusable incident pattern where many tenant-backed public domains fail at once because a shared edge origin drifts from the active host.
+Status: Active reference
+Applies To: Edge-routed public domains, tenant routing, and host recovery triage
+Source Of Truth:
+
+- Sanitized from verified platform incident and recovery work completed on 2026-04-04
+
+Confidence: Medium to high
+Last Reviewed: 2026-04-20 (Central Time)
+
+## Summary
+
+Multiple public domains can fail simultaneously even when draft payloads, runtime APIs, and DNS records look healthy if they inherit a stale shared edge origin. Correcting the shared origin may restore routing, but final recovery can still require application-service repair on the active host.
+
+## User-Visible Symptoms
+
+- multiple public domains fail at once
+- failures vary between 502, 504, connection resets, or generic edge error pages
+- the direct management surface or host may still appear reachable
+- runtime or authoring APIs may remain healthy, which can mislead triage
+
+## Root Cause Pattern
+
+- public domains inherit a shared base edge distribution or routing layer
+- that shared layer still points at a retired or incorrect upstream host
+- the active host may also have stale service state, so fixing the edge layer alone is not always enough
+
+## Recovery Pattern
+
+1. Confirm whether the failing domains share a common edge or tenant-routing layer.
+2. Compare the configured shared origin with the active host that should currently serve the application.
+3. Correct the shared origin first.
+4. Verify the actual application service state on the active host.
+5. If SSH is unavailable, use an alternate management path such as Systems Manager or a serial console.
+6. Repair broken application services or missing images before declaring recovery complete.
+7. Flush or invalidate caches only after origin and service health are both correct.
+
+## Durable Lessons
+
+- when many tenant-backed domains fail together, inspect shared edge inheritance before debugging each site individually
+- treat runtime and authoring API health as separate from edge and host recovery
+- keep alternate management access available on the active host
+- verify container or process health after edge routing is fixed
+
+## Security Rule
+
+Do not record distribution IDs, instance IDs, hostnames, IP allowlists, PEM paths, or other volatile identifiers in committed notes. Keep those details in local-only incident material if they are needed at all.

--- a/ai-notes/future-features-ideas/platform-improvement-opportunities.md
+++ b/ai-notes/future-features-ideas/platform-improvement-opportunities.md
@@ -1,0 +1,48 @@
+# Platform Improvement Opportunities
+
+Date: 2026-04-19 (Central Time)
+Scope: Cross-site product and workflow opportunities promoted from draft work.
+Status: Backlog input
+Applies To: Platform-level UX, authoring workflow, and runtime ergonomics
+Source Of Truth:
+
+- `docs/03-development-guide.md`
+- `docs/11-draft-lifecycle.md`
+- Promoted from local draft findings
+
+Confidence: Medium
+Last Reviewed: 2026-04-19 (Central Time)
+
+## Authoring And QA
+
+- Add a draft-domain consistency validator for folder name, payload domain values, internal links, aliases, and canonical origins.
+- Add a first-class visual-parity checklist artifact to the draft workflow.
+- Add preset reference viewports to the debug workspace.
+- Add screenshot-diff or overlay support for local draft previews.
+- Add a quick-hide mode for debug overlays during visual QA.
+
+## Draft Primitives
+
+- Add a layout blueprint library for common landing structures.
+- Add a stronger draft-safe social-icon pattern.
+- Add host-level classes or styles for leaf components such as `embed-frame`.
+- Add a route-driven shared navigation manifest derived from site config.
+- Add a dedicated structured contact-channels block for professional-services landings.
+- Add a trust-signals component that is not coupled to testimonials.
+- Extend stats-style components to support visible labels.
+- Add per-card CTA destination support where service or offer cards need direct routing.
+
+## Future Site Features
+
+- Add a first-class site-search model instead of draft-only search placeholders.
+- Add navigation performance instrumentation for route bootstrap phases.
+
+## Workflow And Validation
+
+- Add a first-class intake schema or questionnaire-to-payload contract.
+- Add semantic validation on top of structural JSON validation.
+- Add industry-specific blueprints for common verticals such as legal, music, education, and SaaS.
+- Add approval ownership metadata for legal, SEO, translation, and business sign-off.
+- Add asset-presence and placeholder detection before release.
+- Add a regulated-content review profile for industries with compliance risk.
+- Add a deterministic draft smoke-test and readiness gate that covers security, tests, build warnings, manual QA, desktop and mobile browser QA, analytics consent, and localization review.

--- a/ai-notes/how-to/intake-and-approval-workflow.md
+++ b/ai-notes/how-to/intake-and-approval-workflow.md
@@ -1,0 +1,41 @@
+# Intake And Approval Workflow
+
+Date: 2026-04-19 (Central Time)
+Scope: Shared intake and approval workflow for AI-authored landing projects.
+Status: Active
+Applies To: New draft creation, especially multi-language or regulated-industry sites
+Source Of Truth:
+
+- `docs/03-development-guide.md`
+- `docs/11-draft-lifecycle.md`
+- Promoted from local draft findings
+- `.github/skills/zoolanding-frontend-workflow/SKILL.md`
+
+Confidence: High
+Last Reviewed: 2026-04-19 (Central Time)
+
+## Required Intake Shape
+
+Every serious landing draft should have durable answers for:
+
+- project profile and objective
+- audience and positioning
+- brand inputs and visual direction
+- conversion strategy and CTA destinations
+- section-level copy requirements
+- media and asset readiness
+- navigation and information architecture
+- localization rules
+- analytics and consent requirements
+- SEO and structured-data requirements
+- approval ownership
+
+## Approval Rules
+
+- Do not treat incomplete questionnaires as production-ready inputs.
+- If a required answer is unknown, keep it explicit with owner and due date instead of inventing facts.
+- Regulated industries need stronger approval coverage for disclaimers, legal notices, jurisdiction scope, and claim language.
+
+## Reusable Rule
+
+If the landing depends on real business facts, legal copy, translation review, or approval ownership, capture those dependencies before payload generation. Structural draft support is not a substitute for approved intake.

--- a/ai-notes/how-to/recover-host-access-with-ssm.md
+++ b/ai-notes/how-to/recover-host-access-with-ssm.md
@@ -1,0 +1,69 @@
+# Recover Host Access With SSH And Systems Manager
+
+Date: 2026-04-20 (Central Time)
+Scope: Sanitized recovery procedure for restoring host access when SSH is unavailable.
+Status: Active
+Applies To: Active platform hosts where direct SSH is failing or insufficient
+Source Of Truth:
+
+- Sanitized from verified platform recovery work completed on 2026-04-04
+
+Confidence: Medium
+Last Reviewed: 2026-04-20 (Central Time)
+
+## Purpose
+
+Use this procedure when SSH is refusing connections, timing out, or otherwise blocking recovery work on an active host.
+
+## Recommended Recovery Order
+
+1. Recover access through any alternate shell path such as a serial console or existing management channel.
+2. Restore the SSH service and confirm it is listening.
+3. Verify that the Systems Manager agent is installed and running.
+4. Verify that the instance role can talk to Systems Manager.
+5. Confirm the host appears as a managed instance before you rely on it for recovery.
+
+## Restore SSH First
+
+Once you have an alternate shell path, verify:
+
+- the SSH service exists and is running
+- the daemon is listening on the expected port
+- the host firewall is not blocking SSH
+- the daemon configuration does not disable the intended auth method
+
+If SSH still times out after the daemon is healthy, verify the network edge separately:
+
+- security-group or firewall allowlists
+- the current client IP
+- any local key-permission issue on the workstation
+
+## Enable Systems Manager
+
+Confirm all of these are true:
+
+- the Systems Manager agent is installed
+- the agent is enabled on boot and currently running
+- the host role includes the managed Systems Manager core permissions or an equivalent policy set
+- outbound connectivity to the required Systems Manager endpoints is available
+
+If the host sits in a private subnet, provide the required egress path through NAT or VPC endpoints.
+
+## Verify Registration
+
+Before declaring recovery complete:
+
+1. confirm the host appears as an online managed instance
+2. run a simple remote command such as `hostname` and `whoami`
+3. confirm Systems Manager can still be used if SSH fails again later
+
+## Harden After Recovery
+
+- keep Systems Manager enabled on the active host
+- keep SSH as a fallback, not the only access path
+- restrict SSH exposure to controlled access when possible
+- avoid depending on rapidly changing operator-IP allowlists as the sole recovery path
+
+## Security Rule
+
+Do not record instance IDs, role names, IP allowlists, PEM paths, or other volatile access specifics in committed notes. Keep committed guidance procedural and reusable.

--- a/ai-notes/how-to/visual-parity-checklist.md
+++ b/ai-notes/how-to/visual-parity-checklist.md
@@ -1,0 +1,41 @@
+# Visual Parity Checklist
+
+Date: 2026-04-19 (Central Time)
+Scope: Shared visual-parity checklist for replicated or reference-matched landing pages.
+Status: Active
+Applies To: All visual replication or parity tasks
+Source Of Truth:
+
+- `docs/03-development-guide.md`
+- `docs/11-draft-lifecycle.md`
+- Promoted from local draft notes and findings
+
+Confidence: High
+Last Reviewed: 2026-04-19 (Central Time)
+
+## Source Selection
+
+- Prefer one primary source of truth per page.
+- Use a fallback screenshot only when the live reference is unavailable or clearly broken in the tool.
+- Record when integrated-browser limitations make screenshots or normal-browser checks more trustworthy than in-tool rendering.
+
+## Acceptance Pass
+
+Check these in order:
+
+1. Header and navigation state
+2. Hero structure, copy hierarchy, and CTA geometry
+3. Section order and desktop composition
+4. Footer structure, dividers, and external-link treatment
+5. Mobile and narrow-width stacking behavior
+6. Key CTA labels, colors, and spacing
+
+## Validation Rules
+
+- Ignore dev-only panels, overlays, event viewers, and temporary notifications during parity judgment.
+- Judge third-party embeds by outer placement and visible composition, not by trying to restyle the provider internals.
+- If the integrated browser falls back to an unreliable width or style state, document that limitation and rely on local-browser confirmation for sign-off.
+
+## Output Rule
+
+If the parity target will matter again, capture the page-specific baseline locally under `drafts/{domain}/ai_notes/` and distill any reusable validation rule into the committed canonical notes.

--- a/ai-notes/knowledge/draft-authoring-rules.md
+++ b/ai-notes/knowledge/draft-authoring-rules.md
@@ -1,0 +1,47 @@
+# Shared Draft Authoring Rules
+
+Date: 2026-04-19 (Central Time)
+Scope: Shared rules for durable draft authoring and documentation workflow.
+Status: Active
+Applies To: All local drafts and future config-driven landing-page work
+Source Of Truth:
+
+- `docs/03-development-guide.md`
+- `docs/11-draft-lifecycle.md`
+- `docs/DEVELOPER_ONBOARDING.md`
+- Promoted from local draft notes and findings
+
+Confidence: High
+Last Reviewed: 2026-04-20 (Central Time)
+
+## Core Workflow
+
+1. Start in local draft mode first.
+2. Open the intended draft with explicit `draftDomain` and `draftPageId`.
+3. Keep shared shell work at the domain root and page-specific work at the page root.
+4. Validate locally before pushing or publishing.
+5. Distill durable learnings into `ai-notes/` before closing the task.
+
+## Ownership Rules
+
+- Use domain-root files for shared shell, shared variables, shared combos, and shared i18n defaults.
+- Use page-root files for route-specific structure, overrides, and page-level SEO or analytics.
+- Prefer explicit containers and authored structure over large rich-text blobs when exact placement matters.
+
+## Link And Navigation Rules
+
+- Use production-safe relative paths such as `/contact` or `/servicios` inside authored payloads.
+- Reserve `draftDomain` and `draftPageId` query parameters for local preview URLs only.
+- When a live route needs an accented or otherwise fragile slug, use a safe internal route id and map the live-like alias in config.
+
+## Documentation Rules
+
+- Before new work, read the relevant committed notes and inspect local draft `ai_notes/`, `findings/`, and `errors-reports/` folders when they exist.
+- After new work, update baselines, constraints, procedures, incident notes, or future ideas if the learning is durable.
+- Keep repo-level local-only scratch untracked if you need it; do not commit it as canonical guidance.
+
+## Validation Rules
+
+- Distinguish local draft files, authoring draft state, and published runtime state.
+- If a visual change is missing, verify state in that order instead of guessing.
+- If notes and code disagree, verify against code and fix the note.

--- a/ai-notes/knowledge/platform-operations-and-recovery-lessons.md
+++ b/ai-notes/knowledge/platform-operations-and-recovery-lessons.md
@@ -1,0 +1,28 @@
+# Platform Operations And Recovery Lessons
+
+Date: 2026-04-19 (Central Time)
+Scope: Sanitized operational lessons promoted from verified platform incidents and recovery work.
+Status: Active
+Applies To: Zoolanding platform hosting, tenant routing, and host recovery workflows
+Source Of Truth:
+
+- Sanitized from verified platform recovery work completed on 2026-04-04
+
+Confidence: Medium to high
+Last Reviewed: 2026-04-20 (Central Time)
+
+## Public Routing Lesson
+
+If multiple tenant-backed public domains fail at once while the direct management surface still works, check the shared edge or tenant-base origin first. A stale shared origin can break many public domains at the same time even when DNS and application config look healthy.
+
+## Host Recovery Lesson
+
+Keep Systems Manager access available on the active host so recovery does not depend only on SSH. If SSH fails, Systems Manager can provide the control path needed to restore service and then repair SSH separately.
+
+## Service Recovery Lesson
+
+After edge routing is repaired, verify the actual application service state on the active host before declaring the incident closed. A broken container image or missing local image can keep the site down even after the edge layer is healthy again.
+
+## Security Rule
+
+Do not copy instance identifiers, PEM paths, security-group details, or operator IP details into committed notes. Keep volatile operational specifics out of the canonical tree.

--- a/ai-notes/notes/agent-task-workflow.md
+++ b/ai-notes/notes/agent-task-workflow.md
@@ -1,0 +1,47 @@
+# Agent Task Workflow
+
+Date: 2026-04-19 (Central Time)
+Scope: Shared workflow for AI agents and developers working in this repo.
+Status: Active
+Applies To: Every new draft task, feature task, or review task
+Source Of Truth:
+
+- `AGENTS.md`
+- `Codex.md`
+- `docs/DEVELOPER_ONBOARDING.md`
+- `docs/03-development-guide.md`
+
+Confidence: High
+Last Reviewed: 2026-04-20 (Central Time)
+
+## Before Work
+
+1. Read `Codex.md`.
+2. Read `ai-notes/README.md`.
+3. Read the relevant committed notes for the task.
+4. If the task touches an existing local draft, inspect `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, and `drafts/{domain}/errors-reports/` when available.
+5. Read the implementation docs for the task area.
+
+## During Work
+
+- Keep durable reusable guidance in `ai-notes/`.
+- Keep draft-specific history or investigation in `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, or `drafts/{domain}/errors-reports/`.
+- Keep repo-level raw, temporary, or operational output untracked if you need it locally; do not make it part of the committed canonical tree.
+- If a new reusable rule appears, update the appropriate committed note instead of letting it live only in chat history.
+- Prefer repo-local prompt files under `.github/prompts/` for repeated workflows before inventing fresh one-off instructions in chat.
+- Prefer repo-local custom agents under `.github/agents/` for repeated higher-order review roles.
+
+## After Work
+
+- Distill any reusable lesson from local draft notes into a committed note.
+- If no suitable note exists, create one from a template.
+- Audit the work, fix findings, and rerun the audit at least three times before declaring it correct.
+- For draft-affecting tasks, finish with browser QA on every affected draft route in both desktop and mobile viewports.
+- Do a security scrub before saving the note.
+
+## Security Scrub
+
+- Remove secrets, credentials, tokens, signed URLs, raw env values, and PII.
+- Replace volatile infrastructure specifics with reusable generalized guidance.
+- Cite the source of truth for durable claims.
+- If a tool result was incomplete or environment-specific, say so explicitly instead of generalizing.

--- a/ai-notes/notes/legacy-site-notes-layout.md
+++ b/ai-notes/notes/legacy-site-notes-layout.md
@@ -1,0 +1,22 @@
+# Legacy Site Notes Layout
+
+Date: 2026-04-20 (Central Time)
+Scope: Retired marker for the previous committed site-note layout.
+Status: Retired for new work
+Applies To: Historical note migration only
+Source Of Truth:
+
+- `AGENTS.md`
+- `Codex.md`
+- `ai-notes/README.md`
+
+Confidence: High
+Last Reviewed: 2026-04-20 (Central Time)
+
+Committed domain-specific site-note trees are no longer the default workflow.
+
+For active work:
+
+- keep local draft-specific history in `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, and `drafts/{domain}/errors-reports/` when those folders are needed
+- distill only reusable lessons into the committed buckets under `ai-notes/`
+- do not create new committed domain folders for one-off draft history

--- a/ai-notes/templates/README.md
+++ b/ai-notes/templates/README.md
@@ -1,0 +1,22 @@
+Date: 2026-04-20 (Central Time)
+Scope: Template index for new AI and developer notes.
+Status: Active
+Applies To: All future note creation in the canonical ai-notes folder
+Source Of Truth:
+
+- `ai-notes/README.md`
+- `AGENTS.md`
+- `Codex.md`
+  Confidence: High
+  Last Reviewed: 2026-04-20 (Central Time)
+
+# Templates
+
+Use these templates instead of inventing new note shapes:
+
+- [visual-baseline-template.md](./visual-baseline-template.md)
+- [constraint-note-template.md](./constraint-note-template.md)
+- [iteration-log-template.md](./iteration-log-template.md)
+- [future-idea-template.md](./future-idea-template.md)
+- [draft-or-feature-brief-template.md](./draft-or-feature-brief-template.md)
+- [error-report-template.md](./error-report-template.md)

--- a/ai-notes/templates/constraint-note-template.md
+++ b/ai-notes/templates/constraint-note-template.md
@@ -1,0 +1,26 @@
+Date: YYYY-MM-DD (Central Time)
+Scope: Reusable authoring or runtime constraint.
+Status: Draft
+Applies To: `domain`, component, workflow, or shared behavior
+Source Of Truth:
+
+- Related code or doc:
+- Related historical note:
+  Confidence: Low / Medium / High
+  Last Reviewed: YYYY-MM-DD (Central Time)
+
+# {Constraint Name}
+
+## Rule
+
+- State the durable rule plainly.
+
+## Why It Exists
+
+- Explain the verified limitation or behavior.
+
+## How To Work Safely
+
+1. Preferred approach
+2. Validation approach
+3. Escalation or backlog path if the limitation blocks parity

--- a/ai-notes/templates/draft-or-feature-brief-template.md
+++ b/ai-notes/templates/draft-or-feature-brief-template.md
@@ -1,0 +1,33 @@
+Date: YYYY-MM-DD (Central Time)
+Scope: Start-here brief for a new draft or feature.
+Status: Draft
+Applies To: `domain` or feature area
+Source Of Truth:
+
+- Request source:
+- Related docs:
+- Related notes:
+  Confidence: Low / Medium / High
+  Last Reviewed: YYYY-MM-DD (Central Time)
+
+# {Draft Or Feature Brief}
+
+## Goal
+
+-
+
+## Constraints
+
+-
+
+## Relevant Notes To Read First
+
+-
+
+## Acceptance Checks
+
+-
+
+## Open Questions
+
+- Record only unresolved questions that materially affect implementation.

--- a/ai-notes/templates/error-report-template.md
+++ b/ai-notes/templates/error-report-template.md
@@ -1,0 +1,38 @@
+Date: YYYY-MM-DD (Central Time)
+Scope: Sanitized reusable incident note.
+Status: Draft
+Applies To: Shared workflow, platform area, or recurring failure mode
+Source Of Truth:
+
+- Incident source:
+- Related docs:
+  Confidence: Low / Medium / High
+  Last Reviewed: YYYY-MM-DD (Central Time)
+
+# {Incident Name}
+
+## Summary
+
+-
+
+## User-Visible Symptoms
+
+-
+
+## Root Cause Pattern
+
+-
+
+## Recovery Pattern
+
+1.
+2.
+3.
+
+## Durable Lessons
+
+-
+
+## Security Rule
+
+- State which operational specifics must stay out of the committed note.

--- a/ai-notes/templates/future-idea-template.md
+++ b/ai-notes/templates/future-idea-template.md
@@ -1,0 +1,28 @@
+Date: YYYY-MM-DD (Central Time)
+Scope: Durable backlog-grade idea discovered during work.
+Status: Backlog input
+Applies To: `domain`, shared workflow, or platform area
+Source Of Truth:
+
+- Origin note:
+- Related docs:
+  Confidence: Low / Medium / High
+  Last Reviewed: YYYY-MM-DD (Central Time)
+
+# {Idea Name}
+
+## Problem
+
+-
+
+## Proposed Direction
+
+-
+
+## Why It Matters
+
+-
+
+## Notes
+
+- Keep this free of raw brainstorming that has no durable signal.

--- a/ai-notes/templates/iteration-log-template.md
+++ b/ai-notes/templates/iteration-log-template.md
@@ -1,0 +1,32 @@
+Date: YYYY-MM-DD (Central Time)
+Scope: Durable task log for one workstream or pass.
+Status: Draft
+Applies To: `domain`, feature, or workflow
+Source Of Truth:
+
+- Task source:
+- Files or docs reviewed:
+  Confidence: Medium / High
+  Last Reviewed: YYYY-MM-DD (Central Time)
+
+# YYYY-MM-DD {Topic}
+
+## Changes Made
+
+-
+
+## Intent Of The Pass
+
+-
+
+## What Was Verified
+
+-
+
+## What Could Not Be Fully Verified
+
+-
+
+## Next Recommended Check
+
+-

--- a/ai-notes/templates/visual-baseline-template.md
+++ b/ai-notes/templates/visual-baseline-template.md
@@ -1,0 +1,32 @@
+Date: YYYY-MM-DD (Central Time)
+Scope: Visual or behavioral baseline for one page or surface.
+Status: Draft
+Applies To: `domain` / `page`
+Source Of Truth:
+
+- Primary reference:
+- Secondary reference:
+  Confidence: Low / Medium / High
+  Last Reviewed: YYYY-MM-DD (Central Time)
+
+# {Page} Visual Baseline
+
+## Source Of Truth
+
+- Primary reference:
+- Fallback reference:
+- Ignore during review:
+
+## Content And Structure Targets
+
+1. Header
+2. Hero or first-screen composition
+3. Middle sections
+4. CTA treatment
+5. Footer
+
+## Known Validation Caveats
+
+- Integrated-browser limitations:
+- Third-party-surface limitations:
+- Open questions:

--- a/angular.json
+++ b/angular.json
@@ -25,6 +25,12 @@
               {
                 "glob": "**/*",
                 "input": "public"
+              },
+              {
+                "glob": "**/*",
+                "input": "drafts",
+                "output": "drafts",
+                "ignore": ["**/ai_notes/**", "**/findings/**", "**/errors-reports/**", "**/*.md", "**/.gitignore"]
               }
             ],
             "styles": [
@@ -104,6 +110,12 @@
               {
                 "glob": "**/*",
                 "input": "public"
+              },
+              {
+                "glob": "**/*",
+                "input": "drafts",
+                "output": "drafts",
+                "ignore": ["**/ai_notes/**", "**/findings/**", "**/errors-reports/**", "**/*.md", "**/.gitignore"]
               }
             ],
             "styles": [

--- a/docs/02-architecture.md
+++ b/docs/02-architecture.md
@@ -8,7 +8,7 @@ Zoolandingpage is a config-driven Angular application.
 
 The same landing page can exist in three forms:
 
-1. `Local draft files` in the repo under `public/assets/drafts/{domain}/...`.
+1. `Local draft files` in the repo under `drafts/{domain}/...`.
 2. `Authoring draft state` stored by the config authoring API.
 3. `Published runtime state` returned by the runtime API for live traffic.
 
@@ -45,7 +45,7 @@ The frontend renders the same internal component model in both local and product
 Browser URL
   -> draftDomain + draftPageId
   -> DraftRuntimeService
-  -> local files in public/assets/drafts/{domain}/...
+  -> local files in drafts/{domain}/... served at /drafts/...
   -> ConfigBootstrapService
   -> ConfigStoreService
   -> RuntimeService
@@ -143,8 +143,11 @@ These files define page roots, page SEO and analytics, page-specific component o
 ## Draft filesystem layout
 
 ```text
-public/assets/drafts/
+drafts/
   {domain}/
+    ai_notes/
+    findings/
+    errors-reports/
     site-config.json
     components.json
     variables.json
@@ -162,7 +165,7 @@ public/assets/drafts/
       components.json
 ```
 
-The local filesystem layout is still the authoring source of truth for developer and AI-assisted editing.
+The local filesystem layout is still the authoring source of truth for developer and AI-assisted editing. The `ai_notes/`, `findings/`, and `errors-reports/` folders are local draft-specific context only and are not part of the authoring transport contract.
 
 ## Transport contracts
 

--- a/docs/03-development-guide.md
+++ b/docs/03-development-guide.md
@@ -7,7 +7,7 @@ This guide covers the current day-to-day development workflow for Zoolandingpage
 The frontend can work in two different config modes:
 
 1. `Local draft mode`
-   The app loads JSON from `public/assets/drafts/{domain}/...`.
+   The app loads JSON from `drafts/{domain}/...`, served locally at `/drafts/...`.
 2. `Runtime API mode`
    The app loads one `TRuntimeBundlePayload` from the runtime API.
 
@@ -16,11 +16,21 @@ For most feature work, local draft mode is the safest place to start.
 ## Recommended local workflow
 
 1. Start the app locally.
-2. Open the target draft with explicit `draftDomain` and `draftPageId` query parameters.
-3. Edit the local draft files under `public/assets/drafts`.
-4. Refresh and verify the page locally.
-5. If needed, pull from or push to the authoring API with `tools/config-draft-sync.mjs`.
-6. Publish only after the authoring draft is correct.
+2. Read [../ai-notes/README.md](../ai-notes/README.md) plus the relevant committed note before making changes.
+3. Open the target draft with explicit `draftDomain` and `draftPageId` query parameters.
+4. Inspect `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, and `drafts/{domain}/errors-reports/` if they exist for the draft you are changing.
+5. Edit the local draft files under `drafts`.
+6. Refresh and verify the page locally.
+7. If needed, pull from or push to the authoring API with `tools/config-draft-sync.mjs`.
+8. Publish only after the authoring draft is correct.
+9. Distill durable learnings back into the canonical AI notes before closing the task.
+
+## Canonical AI Notes Workflow
+
+- Curated long-lived guidance lives in [../ai-notes/README.md](../ai-notes/README.md).
+- `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, and `drafts/{domain}/errors-reports/` hold local draft-specific history, investigation, and incident notes.
+- If repo-level local-only scratch is needed, keep it untracked under `devonly/`.
+- If a task discovers a reusable baseline, routing rule, embed limitation, readiness gate, or workflow improvement, promote it into the canonical folder.
 
 ## Local draft preview
 
@@ -45,8 +55,11 @@ If you omit `draftDomain` on localhost, you can end up exercising fallback behav
 Use the domain root for shared defaults and the page root for route-specific data.
 
 ```text
-public/assets/drafts/
+drafts/
   {domain}/
+   ai_notes/
+   findings/
+   errors-reports/
     site-config.json
     components.json
     variables.json
@@ -134,7 +147,7 @@ node tools/config-draft-sync.mjs publish --endpoint=https://api.zoolandingpage.c
 
 Use this order when a change is “missing”:
 
-1. Check the local file under `public/assets/drafts`.
+1. Check the local file under `drafts`.
 2. Check whether the authoring draft was pushed.
 3. Check whether that draft was published.
 4. Check the runtime bundle response for the live domain.

--- a/docs/06-deployment.md
+++ b/docs/06-deployment.md
@@ -48,6 +48,9 @@ Recommended deployment order:
 
 Notes for preview and alternate domains:
 
+- Every site should declare at least one managed alias under `*.zoolandingpage.com.mx`, even when a branded domain is planned later.
+- Use that managed Zoolanding alias as the public fallback host from day one.
+- If the branded domain is not live yet, point `site.seo.canonicalOrigin` and page-level `seo.canonical` URLs at the Zoolanding alias until the cutover is real.
 - Put preview or alternate hosts in `site-config.json.aliases`, for example `"aliases": ["test.zoolandingpage.com.mx", "landing-preview.zoolandingpage.com.mx"]`.
 - The authoring Lambda persists alias lookup records in DynamoDB, and the runtime Lambda resolves those aliases back to the canonical site domain at request time.
 - You do not need a second DynamoDB site entry just for a preview host when it should reuse the canonical site's config.
@@ -301,6 +304,12 @@ The canonical site config can also declare reusable aliases:
   "aliases": ["test.zoolandingpage.com.mx", "landing-preview.zoolandingpage.com.mx"]
 }
 ```
+
+Default convention for new sites:
+
+- Keep `domain` set to the intended long-term canonical domain.
+- Always add a managed fallback alias under `*.zoolandingpage.com.mx` in `aliases`.
+- If the branded domain is not live yet, use the Zoolanding alias in `site.seo.canonicalOrigin` and page `seo.canonical` fields until the real-domain cutover is complete.
 
 ### 7.1 First upload from the local draft
 

--- a/docs/11-draft-lifecycle.md
+++ b/docs/11-draft-lifecycle.md
@@ -7,7 +7,7 @@ This guide explains how to create, preview, update, upload, and publish Zoolandi
 Every draft exists in three possible states:
 
 1. `Local draft files`
-   Your working copy in `public/assets/drafts/{domain}/...`.
+   Your working copy in `drafts/{domain}/...`, served locally at `/drafts/...`.
 2. `Authoring draft state`
    The draft stored in the config authoring API.
 3. `Published runtime state`
@@ -15,11 +15,25 @@ Every draft exists in three possible states:
 
 Do not treat those as the same thing. A local file edit affects only state 1 until you push and publish it.
 
+## Read The Canonical Notes First
+
+Before starting a new draft or major refinement pass, read:
+
+1. [../Codex.md](../Codex.md)
+2. [../ai-notes/README.md](../ai-notes/README.md)
+3. the relevant committed note under `ai-notes/`
+4. `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, and `drafts/{domain}/errors-reports/` if the task depends on an existing local draft
+
+After durable work, update the canonical notes so future agents do not have to rediscover the same rules.
+
 ## Local draft structure
 
 ```text
-public/assets/drafts/
+drafts/
   {domain}/
+   ai_notes/
+   findings/
+   errors-reports/
     site-config.json
     components.json
     variables.json
@@ -39,13 +53,18 @@ Domain-root files provide shared defaults. Page-root files override them for one
 
 The current platform does not have a separate scaffold generator for local files. The practical path is:
 
-1. Create a new domain folder under `public/assets/drafts/{domain}`.
+1. Create a new domain folder under `drafts/{domain}`.
 2. Add `site-config.json` for the new domain.
-3. Create at least one page folder such as `default`.
-4. Add `page-config.json` and `components.json` for that page.
-5. Add `variables.json`, `angora-combos.json`, and `i18n/*.json` only when the draft needs them.
+3. Declare at least one managed alias under `*.zoolandingpage.com.mx` in `site-config.json.aliases`, for example `brand.zoolandingpage.com.mx`.
+4. If the branded domain is not live yet, point `site.seo.canonicalOrigin` and each page `seo.canonical` URL at that Zoolanding alias until cutover.
+5. Create at least one page folder such as `default`.
+6. Add `page-config.json` and `components.json` for that page.
+7. Add `variables.json`, `angora-combos.json`, and `i18n/*.json` only when the draft needs them.
+8. Create `ai_notes/`, `findings/`, and `errors-reports/` only when the draft needs local history, investigation, or incident tracking that should stay out of the committed canonical notes.
 
 For a shared header/footer or repeated site UI, use the domain-root `components.json` instead of duplicating the same component definitions across pages.
+
+Draft-authored navigation and CTA links should be production-safe relative paths such as `/contact` or `/servicios`. Reserve `draftDomain` and `draftPageId` query parameters for local preview URLs, not authored site navigation.
 
 ## Preview a draft locally
 
@@ -57,6 +76,30 @@ http://127.0.0.1:4200/?draftDomain=newsite.example&draftPageId=default
 ```
 
 If you are using the Docker dev server on another port, keep the same query parameters and only change the host/port.
+
+## Smoke-check local drafts against live aliases
+
+Once your local dev server is running, you can automate the same browser-level smoke checks that are usually done manually:
+
+```bash
+node tools/draft-smoke-check.mjs --local-base-url=http://127.0.0.1:4200
+```
+
+What this script validates:
+
+1. every local draft route renders a non-empty title and a first heading
+2. the local preview does not fall into the `Unresolved draft` fallback
+3. any draft with a managed `*.zoolandingpage.com.mx` alias matches its live counterpart for title, first heading, and key header controls such as the search trigger and mobile navigation trigger
+
+Useful options:
+
+- `--domain=example.com` to limit the run to one draft; repeat the flag for multiple drafts
+- `--browser-path=...` if Chromium is not installed in a default location
+- `--output=reports/draft-smoke.json` to save the structured report to disk
+
+The structured JSON report records both desktop and mobile viewport results for every checked route.
+
+Before closing draft-affecting work, also open every affected draft route in browser QA on both desktop and mobile viewports, fix any visible, runtime, console, or network issue you find there, and rerun the impacted checks.
 
 ## Inspect the current CLI
 
@@ -119,25 +162,31 @@ node tools/config-draft-sync.mjs publish --endpoint=https://api.zoolandingpage.c
 
 Publishing changes the authoring state only insofar as it promotes the current draft to the published version pointer. It does not guarantee that live frontend caches or deployments have already refreshed.
 
+If the custom-domain authoring endpoint resets the connection during publish, retry the same `publishDraft` request through the raw API Gateway endpoint documented in [06-deployment.md](06-deployment.md). If the raw endpoint succeeds, the problem is in the API front door, not in the authoring Lambda action itself.
+
 ## Recommended workflows
 
 ### Update an existing site
 
 1. Pull the latest draft.
-2. Edit local files.
-3. Preview locally.
-4. Push the local draft.
-5. Publish it.
-6. Validate the runtime bundle and the live site separately.
+2. Read the relevant committed notes and inspect the local draft `ai_notes/`, `findings/`, and `errors-reports/` folders when they exist.
+3. Edit local files.
+4. Preview locally.
+5. Push the local draft.
+6. Publish it.
+7. Validate the runtime bundle and the live site separately.
+8. Record durable learnings in the canonical AI notes.
 
 ### Create a new site
 
 1. Create the local draft tree.
-2. Preview locally.
-3. Upload any required public assets.
-4. Create the site in the authoring API.
-5. Publish it.
-6. Validate the runtime bundle and then validate the live site.
+2. Create local `ai_notes/`, `findings/`, and `errors-reports/` folders only if the draft needs local history, investigation, or incident tracking.
+3. Preview locally.
+4. Upload any required public assets.
+5. Create the site in the authoring API.
+6. Publish it.
+7. Validate the runtime bundle and then validate the live site.
+8. Distill reusable guidance from the new draft into `ai-notes/`.
 
 ## What to check when a published change is not visible
 

--- a/docs/DEVELOPER_ONBOARDING.md
+++ b/docs/DEVELOPER_ONBOARDING.md
@@ -10,6 +10,7 @@ By the end of this guide you should be able to:
 2. Open a specific draft by `domain` and `pageId`.
 3. Understand the difference between local drafts, authoring drafts, and published runtime state.
 4. Know where to look when a landing page change is not showing up.
+5. Know where the canonical AI and developer guidance lives before starting new work.
 
 ## Prerequisites
 
@@ -38,7 +39,7 @@ npm start
 Before touching any landing page config, keep these states separate:
 
 1. `Local draft files`
-   Files under `public/assets/drafts/{domain}/...` in your working copy.
+   Files under `drafts/{domain}/...` in your working copy, served locally at `/drafts/...`.
 2. `Authoring draft state`
    The draft stored in the authoring API for a domain.
 3. `Published runtime state`
@@ -59,8 +60,11 @@ You can swap only the values after `draftDomain` and `draftPageId` to move betwe
 ## Learn the draft file layout
 
 ```text
-public/assets/drafts/
+drafts/
   {domain}/
+      ai_notes/
+      findings/
+      errors-reports/
     site-config.json
     components.json
     variables.json
@@ -80,17 +84,32 @@ Domain-root files are shared defaults. Page-root files override them for one rou
 
 Read these in order:
 
-1. [02-architecture.md](02-architecture.md)
-2. [03-development-guide.md](03-development-guide.md)
-3. [11-draft-lifecycle.md](11-draft-lifecycle.md)
-4. [12-public-assets-and-file-uploads.md](12-public-assets-and-file-uploads.md)
-5. [api-driven-config/README.md](api-driven-config/README.md)
+1. [../ai-notes/README.md](../ai-notes/README.md)
+2. [02-architecture.md](02-architecture.md)
+3. [03-development-guide.md](03-development-guide.md)
+4. [11-draft-lifecycle.md](11-draft-lifecycle.md)
+5. [12-public-assets-and-file-uploads.md](12-public-assets-and-file-uploads.md)
+6. [api-driven-config/README.md](api-driven-config/README.md)
 
 If you are touching analytics or stats integrations, also read:
 
 - [05-analytics-tracking.md](05-analytics-tracking.md)
 - [08-data-dropper-lambda.md](08-data-dropper-lambda.md)
 - [09-quick-stats-lambda.md](09-quick-stats-lambda.md)
+
+## AI Notes Workflow
+
+Before new draft or feature work:
+
+1. Open [../Codex.md](../Codex.md).
+2. Open [../ai-notes/README.md](../ai-notes/README.md).
+3. Read the relevant committed note and inspect local draft `ai_notes/`, `findings/`, and `errors-reports/` folders when they exist before editing files.
+
+After durable work:
+
+1. Distill reusable guidance into `ai-notes/` or create a new note from a template.
+2. Keep draft-specific scratch or temporary investigation output in `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, or `drafts/{domain}/errors-reports/`.
+3. Keep repo-level local-only scratch untracked if you need it.
 
 ## First useful commands
 
@@ -100,7 +119,7 @@ Inspect the draft CLI:
 node tools/config-draft-sync.mjs help
 ```
 
-Pull the current authoring draft into your local `public/assets/drafts` tree:
+Pull the current authoring draft into your local `drafts` tree:
 
 ```bash
 node tools/config-draft-sync.mjs pull --endpoint=https://api.zoolandingpage.com.mx/config-authoring --domain=zoolandingpage.com.mx
@@ -122,7 +141,7 @@ node tools/config-draft-sync.mjs publish --endpoint=https://api.zoolandingpage.c
 
 Use this quick decision table:
 
-- Local preview is wrong: check `public/assets/drafts`, the draft URL, and runtime validation errors.
+- Local preview is wrong: check `drafts`, the draft URL, and runtime validation errors.
 - Pull or push fails: check the authoring endpoint, CLI arguments, and the current package shape.
 - Publish succeeds but live content is stale: compare runtime bundle output with the deployed frontend/app behavior.
 - Images or media do not load: check the public asset URL, upload key, CDN path, and bucket/CORS configuration.

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,15 @@ Coding standards and development workflow.
 - Performance optimization guidelines
 - Security best practices
 
+### 🧠 [ai-notes](../ai-notes/README.md)
+
+Canonical, long-lived guidance promoted from local draft context and sanitized local-only operational notes.
+
+- Shared draft-authoring and QA rules
+- Shared draft-authoring constraints, QA rules, and reusable workflow guidance
+- Templates for future AI and developer notes
+- Agent workflow guidance for reading and updating durable knowledge
+
 ### 🎨 [NGX-Angora-CSS Integration](./04-ngx-angora-css.md)
 
 Comprehensive styling system guide.
@@ -169,9 +178,10 @@ Zoolandingpage serves dual purposes:
 ### For New Developers
 
 1. **Start Here**: [Getting Started Guide](./01-getting-started.md)
-2. **Understand the Architecture**: [Project Architecture](./02-architecture.md)
-3. **Learn the Standards**: [Development Guide](./03-development-guide.md)
-4. **Master the Styling**: [NGX-Angora-CSS Integration](./04-ngx-angora-css.md)
+2. **Read The Canonical AI Notes**: [ai-notes](../ai-notes/README.md)
+3. **Understand the Architecture**: [Project Architecture](./02-architecture.md)
+4. **Learn the Standards**: [Development Guide](./03-development-guide.md)
+5. **Master the Styling**: [NGX-Angora-CSS Integration](./04-ngx-angora-css.md)
 
 ### Docker Development (Recommended)
 

--- a/docs/api-driven-config/02-component-model.md
+++ b/docs/api-driven-config/02-component-model.md
@@ -10,7 +10,7 @@ This doc describes how to author `TGenericComponent` definitions so they are com
 
 - Type union: `src/app/shared/components/wrapper-orchestrator/wrapper-orchestrator.types.ts`
 - Authored storage: `components.json` now stores `components` as an array of component objects, not a map keyed by id.
-- Draft scope: shared site components can live at `public/assets/drafts/{domain}/components.json`, while page-owned components stay at `public/assets/drafts/{domain}/{pageId}/components.json`.
+- Draft scope: shared site components can live at `drafts/{domain}/components.json`, while page-owned components stay at `drafts/{domain}/{pageId}/components.json`.
 
 ## Common fields
 
@@ -158,7 +158,7 @@ Runtime note:
 
 - Child composition is ID-only.
 - `components.json` should use string IDs so payloads stay serializable, stable, and export-safe.
-- Debug workspace tooling is now authored as a separate payload set under `public/assets/drafts/_debug/debug-workspace/` or the equivalent API endpoints. Keep those component IDs out of active page payloads unless the page explicitly owns the same UI.
+- Debug workspace tooling is now authored as a separate payload set under `drafts/_debug/debug-workspace/` or the equivalent API endpoints. Keep those component IDs out of active page payloads unless the page explicitly owns the same UI.
 
 ## Interaction scopes and inputs
 

--- a/docs/api-driven-config/11-draft-migration.md
+++ b/docs/api-driven-config/11-draft-migration.md
@@ -7,7 +7,7 @@ The original migration from TypeScript-owned component constants to JSON drafts 
 ## Draft root layout
 
 ```text
-public/assets/drafts/
+drafts/
   {domain}/
     site-config.json
     components.json
@@ -75,7 +75,7 @@ That means the filesystem layout above maps directly to `TAuthoringDraftPackage.
 
 If you still use the debug/export tooling in the browser, treat it as a convenience path only. The normal long-term workflow is:
 
-1. author local files in `public/assets/drafts`
+1. author local files in `drafts`
 2. preview locally
 3. push with `tools/config-draft-sync.mjs`
 4. publish when ready

--- a/docs/api-driven-config/README.md
+++ b/docs/api-driven-config/README.md
@@ -18,7 +18,7 @@ Then use this folder as the reference layer.
 
 ### Authored local files
 
-The draft filesystem under `public/assets/drafts/{domain}/...`.
+The draft filesystem under `drafts/{domain}/...`, served locally at `/drafts/...`.
 
 ### Authoring transport
 

--- a/docs/automatic-config-creator/README.md
+++ b/docs/automatic-config-creator/README.md
@@ -4,5 +4,8 @@ This folder is reserved for tooling/docs that help generate `TGenericComponent` 
 
 If your goal is to have an AI assistant generate configs that can be stored in an API, start here:
 
+- [../../ai-notes/README.md](../../ai-notes/README.md)
 - [../api-driven-config/README.md](../api-driven-config/README.md)
 - Condition DSL and handler catalog: [../api-driven-config/09-condition-instructions.md](../api-driven-config/09-condition-instructions.md)
+
+Before generating a new config-heavy draft, read the relevant committed notes from `ai-notes/` and inspect local `drafts/{domain}/ai_notes/`, `drafts/{domain}/findings/`, or `drafts/{domain}/errors-reports/` when they exist. After the task, promote any durable workflow or authoring rule back into the canonical folder instead of leaving it only in local scratch.

--- a/drafts/.gitignore
+++ b/drafts/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "karma-coverage": "^2.2.1",
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "~2.1.0",
+        "playwright-core": "^1.59.1",
         "typescript": "~5.8.2"
       }
     },
@@ -7817,6 +7818,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "config:push": "node tools/config-draft-sync.mjs push",
     "config:create": "node tools/config-draft-sync.mjs create",
     "config:publish": "node tools/config-draft-sync.mjs publish",
+    "drafts:smoke": "node tools/draft-smoke-check.mjs",
+    "test:draft-smoke": "node --test tools/tests/draft-smoke-check.spec.mjs",
+    "test:draft-context": "npm run build && node --test tools/tests/draft-local-context.spec.mjs",
     "ci:budgets": "ng build --configuration production",
     "ci:perf": "node tools/perf-baseline.mjs"
   },
@@ -62,6 +65,7 @@
     "karma-coverage": "^2.2.1",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
+    "playwright-core": "^1.59.1",
     "typescript": "~5.8.2"
   }
 }

--- a/plan/phase 2/plan.md
+++ b/plan/phase 2/plan.md
@@ -75,15 +75,15 @@ This phase turns the Angular app into a generic shell that renders landing pages
 - Drafts live in gitignored files.
 - Local development should default to drafts (to emulate API loading).
 - Suggested structure (public assets):
-  - /public/assets/drafts/{domain}/{pageId}/page-config.json
-  - /public/assets/drafts/{domain}/{pageId}/components.json
-  - /public/assets/drafts/{domain}/{pageId}/angora-combos.json
-  - /public/assets/drafts/{domain}/{pageId}/variables.json
-  - /public/assets/drafts/{domain}/{pageId}/i18n/en.json
-  - /public/assets/drafts/{domain}/{pageId}/i18n/es.json
-  - /public/assets/drafts/{domain}/{pageId}/seo.json
-  - /public/assets/drafts/{domain}/{pageId}/structured-data.json
-  - /public/assets/drafts/{domain}/{pageId}/analytics-config.json
+  - /drafts/{domain}/{pageId}/page-config.json
+  - /drafts/{domain}/{pageId}/components.json
+  - /drafts/{domain}/{pageId}/angora-combos.json
+  - /drafts/{domain}/{pageId}/variables.json
+  - /drafts/{domain}/{pageId}/i18n/en.json
+  - /drafts/{domain}/{pageId}/i18n/es.json
+  - /drafts/{domain}/{pageId}/seo.json
+  - /drafts/{domain}/{pageId}/structured-data.json
+  - /drafts/{domain}/{pageId}/analytics-config.json
 - Current TS consts in ConfigurationsOrchestratorService migrate to drafts.
 
 ## Phase 2 Structure

--- a/plan/phase 3/idea.md
+++ b/plan/phase 3/idea.md
@@ -58,7 +58,7 @@ Proposed manifest payload (example):
   },
   "overrides": {
     "dev": {
-      "components": "/assets/drafts/zoolandingpage.com.mx/default/components.json"
+      "components": "/drafts/zoolandingpage.com.mx/default/components.json"
     }
   },
   "dependencies": [

--- a/src/app/core/components/app-shell/app-shell.analytics.spec.ts
+++ b/src/app/core/components/app-shell/app-shell.analytics.spec.ts
@@ -77,6 +77,8 @@ describe('AppShellComponent analytics', () => {
       'updateClasses',
       'updateColors',
     ]);
+    angoraSpy.indicatorClass = 'ank';
+    angoraSpy.abreviationsClasses = {};
     angoraSpy.timeBetweenReCreate = 300;
     await TestBed.configureTestingModule({
       imports: [AppShellComponent],
@@ -148,19 +150,22 @@ describe('AppShellComponent analytics', () => {
     TestBed.resetTestingModule();
   });
 
-  it('fires one page_view on initial navigation', async () => {
+  it('tracks the initial bootstrap page view once and records later navigations separately', async () => {
     const fixture = TestBed.createComponent(AppShellComponent);
     fixture.detectChanges();
     await new Promise((resolve) => setTimeout(resolve, 0));
     fixture.detectChanges();
+
+    let pageViews = analyticsSpy.track.calls.all().filter((call) => call.args[0] === 'page_view');
+    expect(pageViews.length).toBe(1);
+
     const router = TestBed.inject(Router);
     await router.navigateByUrl('/?nav=1');
 
     expect(analyticsSpy.track).toHaveBeenCalled();
-    const calls = analyticsSpy.track.calls.all();
-    // Filter for page_view
-    const pageViews = calls.filter(c => c.args[0] === 'page_view');
-    expect(pageViews.length).toBe(1);
+    pageViews = analyticsSpy.track.calls.all().filter((call) => call.args[0] === 'page_view');
+    expect(pageViews.length).toBe(2);
+    expect(pageViews[1]?.args[1]).toEqual(jasmine.objectContaining({ label: '/?nav=1' }));
   });
 
   it('delegates draft engagement observers to the analytics service', async () => {

--- a/src/app/core/components/app-shell/app-shell.component.html
+++ b/src/app/core/components/app-shell/app-shell.component.html
@@ -1,3 +1,8 @@
+@if (showNavigationProgress()) {
+<div class="ank-position-fixed ank-top-0 ank-left-0 ank-right-0 ank-zIndex-2000 ank-pointerEvents-none">
+  <generic-progress-bar [mode]="'indeterminate'" color="secondary"></generic-progress-bar>
+</div>
+}
 <wrapper-orchestrator [componentsIds]="rootComponentsIds()"></wrapper-orchestrator>
 @if (showClientOnlyHosts) {
 <generic-toast-host (analyticsEvent)="handleAnalyticsEvent($event)"></generic-toast-host>

--- a/src/app/core/components/app-shell/app-shell.component.ts
+++ b/src/app/core/components/app-shell/app-shell.component.ts
@@ -1,4 +1,5 @@
 import { RuntimeService } from "@/app/core/services/runtime.service";
+import { GenericProgressBarComponent } from "@/app/shared/components/generic-progress-bar";
 import { WrapperOrchestrator } from "@/app/shared/components/wrapper-orchestrator/wrapper-orchestrator.component";
 import { ConfigStoreService } from "@/app/shared/services/config-store.service";
 import { ConfigurationsOrchestratorService } from "@/app/shared/services/configurations-orchestrator";
@@ -36,6 +37,7 @@ import { DebugWorkspaceComponent } from "../debug-workspace/debug-workspace.comp
   imports: [
     AsyncPipe,
     WrapperOrchestrator,
+    GenericProgressBarComponent,
     GenericModalComponent,
     GenericToastComponent,
     DebugWorkspaceComponent,
@@ -64,6 +66,7 @@ export class AppShellComponent {
   private readonly configStore = inject(ConfigStoreService);
   private readonly seo = inject(SeoMetadataService);
   readonly runtime = inject(RuntimeService);
+  readonly showNavigationProgress = this.runtime.showNavigationProgress;
 
   readonly rootComponentsIds = this.runtime.rootComponentsIds;
   readonly modalRootIds = this.runtime.modalRootIds;

--- a/src/app/core/components/debug-workspace/debug-workspace.component.spec.ts
+++ b/src/app/core/components/debug-workspace/debug-workspace.component.spec.ts
@@ -6,6 +6,7 @@ import { WrapperOrchestrator } from '../../../shared/components/wrapper-orchestr
 import { AnalyticsService } from '../../../shared/services/analytics.service';
 import { ConfigStoreService } from '../../../shared/services/config-store.service';
 import { DraftRuntimeService } from '../../../shared/services/draft-runtime.service';
+import { VariableStoreService } from '../../../shared/services/variable-store.service';
 import { DebugWorkspaceComponent } from './debug-workspace.component';
 
 @Component({
@@ -46,6 +47,16 @@ describe('DebugWorkspaceComponent', () => {
                     provide: ConfigStoreService,
                     useValue: {
                         validationIssues: () => [],
+                    },
+                },
+                {
+                    provide: VariableStoreService,
+                    useValue: {
+                        getString: (path: string) => ({
+                            'ui.debug.draftButtons.baseClasses': 'ank-border-1px ank-padding-8px',
+                            'ui.debug.draftButtons.selectedClasses': 'ank-bg-accentColor',
+                            'ui.debug.draftButtons.unselectedClasses': 'ank-bg-transparent',
+                        }[path] ?? ''),
                     },
                 },
                 {

--- a/src/app/core/services/runtime.service.spec.ts
+++ b/src/app/core/services/runtime.service.spec.ts
@@ -37,6 +37,7 @@ describe('RuntimeService', () => {
     const analyticsTrack = jasmine.createSpy('track').and.resolveTo(undefined);
     const analyticsStartPageEngagementTracking = jasmine.createSpy('startPageEngagementTracking');
     const analyticsStopPageEngagementTracking = jasmine.createSpy('stopPageEngagementTracking');
+    const prefetchRoute = jasmine.createSpy('prefetchRoute').and.resolveTo(undefined);
     let loadSiteConfig: jasmine.Spy;
     let bootstrapLoad: jasmine.Spy;
     let setCombos: jasmine.Spy;
@@ -102,6 +103,7 @@ describe('RuntimeService', () => {
         analyticsTrack.calls.reset();
         analyticsStartPageEngagementTracking.calls.reset();
         analyticsStopPageEngagementTracking.calls.reset();
+        prefetchRoute.calls.reset();
 
         TestBed.configureTestingModule({
             providers: [
@@ -117,6 +119,7 @@ describe('RuntimeService', () => {
                     provide: ConfigSourceService,
                     useValue: {
                         loadSiteConfig,
+                        prefetchRoute,
                         loadDebugWorkspacePageConfig: jasmine.createSpy('loadDebugWorkspacePageConfig').and.resolveTo(null),
                         loadDebugWorkspaceComponents: jasmine.createSpy('loadDebugWorkspaceComponents').and.resolveTo(null),
                         loadDebugWorkspaceCombos: jasmine.createSpy('loadDebugWorkspaceCombos').and.resolveTo(null),
@@ -211,6 +214,19 @@ describe('RuntimeService', () => {
             pageId: 'servicios',
             rootIds: ['servicios-root'],
             modalRootIds: expectedModalRootIds,
+        });
+    });
+
+    it('prefetches sibling routes after a successful draft bootstrap', async () => {
+        const service = TestBed.inject(RuntimeService);
+
+        window.history.replaceState({}, '', '/home?draftDomain=pamelabetancourt.com');
+        await service.initialize('es');
+
+        expect(prefetchRoute).toHaveBeenCalledOnceWith('pamelabetancourt.com', {
+            pageId: 'servicios',
+            lang: 'es',
+            path: '/servicios',
         });
     });
 

--- a/src/app/core/services/runtime.service.ts
+++ b/src/app/core/services/runtime.service.ts
@@ -15,6 +15,7 @@ import { filter } from 'rxjs/operators';
 
 @Injectable({ providedIn: 'root' })
 export class RuntimeService {
+    private readonly navigationProgressDelayMs = 120;
     private readonly configBootstrap = inject(ConfigBootstrapService);
     private readonly configSource = inject(ConfigSourceService);
     private readonly orchestrator = inject(ConfigurationsOrchestratorService);
@@ -32,6 +33,8 @@ export class RuntimeService {
     readonly modalRootIds = signal<readonly string[]>([]);
     readonly debugWorkspaceRootIds = signal<readonly string[]>([]);
     readonly debugWorkspaceModalRootIds = signal<readonly string[]>([]);
+    readonly navigationPending = signal(false);
+    readonly showNavigationProgress = signal(false);
     private initializeQueue: Promise<void> = Promise.resolve();
     private debugWorkspaceEnabled = false;
     private debugWorkspaceInit: Promise<void> | null = null;
@@ -40,6 +43,8 @@ export class RuntimeService {
     private currentLanguageResolver: (() => string) | null = null;
     private showDebugWorkspaceResolver: (() => boolean) | null = null;
     private initialPageViewTracked = false;
+    private latestNavigationRequestId = 0;
+    private navigationProgressTimer: number | null = null;
 
     connect(options: {
         host: HTMLElement;
@@ -72,6 +77,13 @@ export class RuntimeService {
         this.navigationSubscription?.unsubscribe();
         this.navigationSubscription = null;
         this.combosService.stopCssRuntime();
+        this.navigationPending.set(false);
+        this.showNavigationProgress.set(false);
+
+        if (this.navigationProgressTimer) {
+            clearTimeout(this.navigationProgressTimer);
+            this.navigationProgressTimer = null;
+        }
 
         try {
             this.cssMutationObserver?.disconnect();
@@ -186,6 +198,7 @@ export class RuntimeService {
         this.combosService.scheduleCssCreate();
         this.analytics.initializeRuntimeState();
         this.analytics.startPageEngagementTracking(this.configStore.analytics());
+        this.prefetchSiblingRoutes(domain, pageId, lang, context.path);
         this.trackInitialPageView();
     }
 
@@ -230,6 +243,8 @@ export class RuntimeService {
         this.navigationSubscription = this.router.events
             .pipe(filter((event): event is NavigationEnd => event instanceof NavigationEnd))
             .subscribe((event) => {
+                const transitionId = this.beginNavigationTransition();
+
                 void this.analytics.track(this.analytics.pageViewEventName(), {
                     category: AnalyticsCategories.Navigation,
                     label: event.urlAfterRedirects,
@@ -239,8 +254,80 @@ export class RuntimeService {
                 void this.initialize(lang)
                     .catch((error) => {
                         console.error('[Runtime] Runtime refresh failed after navigation.', error);
-                    });
+                    })
+                    .finally(() => this.completeNavigationTransition(transitionId));
             });
+    }
+
+    private beginNavigationTransition(): number {
+        if (!this.isBrowser) {
+            return 0;
+        }
+
+        const requestId = ++this.latestNavigationRequestId;
+        this.navigationPending.set(true);
+        this.showNavigationProgress.set(false);
+
+        if (this.navigationProgressTimer) {
+            clearTimeout(this.navigationProgressTimer);
+        }
+
+        this.navigationProgressTimer = window.setTimeout(() => {
+            if (!this.navigationPending() || this.latestNavigationRequestId !== requestId) {
+                return;
+            }
+
+            this.showNavigationProgress.set(true);
+        }, this.navigationProgressDelayMs);
+
+        return requestId;
+    }
+
+    private completeNavigationTransition(requestId: number): void {
+        if (!this.isBrowser || requestId === 0 || requestId !== this.latestNavigationRequestId) {
+            return;
+        }
+
+        if (this.navigationProgressTimer) {
+            clearTimeout(this.navigationProgressTimer);
+            this.navigationProgressTimer = null;
+        }
+
+        this.navigationPending.set(false);
+        this.showNavigationProgress.set(false);
+    }
+
+    private prefetchSiblingRoutes(domain: string, pageId: string, lang: string | undefined, currentPath: string): void {
+        const siteConfig = this.configStore.siteConfig();
+        const routes = siteConfig?.routes ?? [];
+        if (!domain || routes.length === 0) {
+            return;
+        }
+
+        const seen = new Set<string>();
+        routes.forEach((route) => {
+            const routePageId = String(route?.pageId ?? '').trim();
+            const routePath = String(route?.path ?? '').trim();
+            if (!routePageId || !routePath) {
+                return;
+            }
+
+            const routeKey = `${ routePageId }::${ routePath }`;
+            if (seen.has(routeKey)) {
+                return;
+            }
+
+            seen.add(routeKey);
+            if (routePageId === pageId && routePath === currentPath) {
+                return;
+            }
+
+            void this.configSource.prefetchRoute(domain, {
+                pageId: routePageId,
+                lang,
+                path: routePath,
+            });
+        });
     }
 
     private bindCssMutationRefresh(root: HTMLElement): void {

--- a/src/app/core/services/runtime.service.ts
+++ b/src/app/core/services/runtime.service.ts
@@ -16,6 +16,7 @@ import { filter } from 'rxjs/operators';
 @Injectable({ providedIn: 'root' })
 export class RuntimeService {
     private readonly navigationProgressDelayMs = 120;
+    private readonly prefetchSiblingCap = 5;
     private readonly configBootstrap = inject(ConfigBootstrapService);
     private readonly configSource = inject(ConfigSourceService);
     private readonly orchestrator = inject(ConfigurationsOrchestratorService);
@@ -305,21 +306,26 @@ export class RuntimeService {
         }
 
         const seen = new Set<string>();
-        routes.forEach((route) => {
+        let prefetchCount = 0;
+        for (const route of routes) {
+            if (prefetchCount >= this.prefetchSiblingCap) {
+                break;
+            }
+
             const routePageId = String(route?.pageId ?? '').trim();
             const routePath = String(route?.path ?? '').trim();
             if (!routePageId || !routePath) {
-                return;
+                continue;
             }
 
             const routeKey = `${ routePageId }::${ routePath }`;
             if (seen.has(routeKey)) {
-                return;
+                continue;
             }
 
             seen.add(routeKey);
             if (routePageId === pageId && routePath === currentPath) {
-                return;
+                continue;
             }
 
             void this.configSource.prefetchRoute(domain, {
@@ -327,7 +333,8 @@ export class RuntimeService {
                 lang,
                 path: routePath,
             });
-        });
+            prefetchCount++;
+        }
     }
 
     private bindCssMutationRefresh(root: HTMLElement): void {

--- a/src/app/shared/components/generic-dropdown/generic-dropdown.component.spec.ts
+++ b/src/app/shared/components/generic-dropdown/generic-dropdown.component.spec.ts
@@ -1,6 +1,8 @@
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NavigationEnd, Router } from '@angular/router';
+import { Subject } from 'rxjs';
 import { LanguageService } from '../../services/language.service';
 import { GenericDropdown } from './generic-dropdown.component';
 import type { DropdownItem } from './generic-dropdown.types';
@@ -28,8 +30,21 @@ class HostTestComponent {
 describe('GenericDropdown', () => {
   let fixture: ComponentFixture<HostTestComponent>;
   let overlayContainer: OverlayContainer;
+  let routerEvents: Subject<unknown>;
   beforeEach(async () => {
-    await TestBed.configureTestingModule({ imports: [HostTestComponent] }).compileComponents();
+    routerEvents = new Subject<unknown>();
+
+    await TestBed.configureTestingModule({
+      imports: [HostTestComponent],
+      providers: [
+        {
+          provide: Router,
+          useValue: {
+            events: routerEvents.asObservable(),
+          },
+        },
+      ],
+    }).compileComponents();
     fixture = TestBed.createComponent(HostTestComponent);
     overlayContainer = TestBed.inject(OverlayContainer);
     fixture.detectChanges();
@@ -68,5 +83,31 @@ describe('GenericDropdown', () => {
     expect(component.normalizedItems()[0]?.label).toBe('Contacto');
     expect(component.normalizedItems()[0]?.value).toBe('contact');
     expect(component.itemHref(component.normalizedItems()[0])).toBe('#contact');
+  });
+
+  it('preserves the configured selected option when focus moves to the first opened item', () => {
+    const button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+
+    button.click();
+    fixture.detectChanges();
+
+    const options = overlayContainer.getContainerElement().querySelectorAll('a[role="option"]');
+
+    expect(options[0]?.getAttribute('aria-selected')).toBe('false');
+    expect(options[1]?.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('closes an opened menu when the Angular route changes', () => {
+    const button = fixture.nativeElement.querySelector('button') as HTMLButtonElement;
+    const component = fixture.debugElement.children[0].componentInstance as GenericDropdown;
+
+    button.click();
+    fixture.detectChanges();
+    expect(component.opened()).toBeTrue();
+
+    routerEvents.next(new NavigationEnd(1, '/home', '/servicios'));
+    fixture.detectChanges();
+
+    expect(component.opened()).toBeFalse();
   });
 });

--- a/src/app/shared/components/generic-dropdown/generic-dropdown.component.ts
+++ b/src/app/shared/components/generic-dropdown/generic-dropdown.component.ts
@@ -18,6 +18,8 @@ import {
   ViewChild,
   ViewContainerRef
 } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
 import { resolveLocaleMapValue } from '../../i18n/locale.utils';
 import { AngoraCombosService } from '../../services/angora-combos.service';
 import { LanguageService } from '../../services/language.service';
@@ -45,6 +47,7 @@ export class GenericDropdown {
   private readonly vcr = inject(ViewContainerRef);
   private readonly combos = inject(AngoraCombosService);
   private readonly language = inject(LanguageService);
+  private readonly router = inject(Router, { optional: true });
   private readonly appRef = inject(ApplicationRef);
   private readonly injector = inject(Injector);
   private overlayRef: OverlayRef | null = null;
@@ -95,11 +98,28 @@ export class GenericDropdown {
   readonly activeIndex = signal<number>(-1); // exposed for aria-activedescendant
   private menuItems: HTMLElement[] = [];
   private triggerBtn!: HTMLButtonElement;
+  private navigationSubscription: Subscription | null = null;
   @Input('menuTpl') menuTpl!: TemplateRef<unknown>; // scaffold placeholder (template reference)
   @ViewChild('defaultMenuTpl', { static: true }) private defaultMenuTpl!: TemplateRef<MenuTemplateContext>;
+
+  constructor() {
+    this.navigationSubscription = this.router?.events.subscribe((event) => {
+      if (!(event instanceof NavigationEnd) || !this.opened()) {
+        return;
+      }
+
+      this.close(false);
+    }) ?? null;
+  }
+
   ngAfterViewInit(): void {
     // capture trigger for focus restoration
     this.triggerBtn = this.host.nativeElement.querySelector('button[aria-haspopup]') as HTMLButtonElement;
+  }
+
+  ngOnDestroy(): void {
+    this.navigationSubscription?.unsubscribe();
+    this.navigationSubscription = null;
   }
 
   toggle(): void {
@@ -295,7 +315,7 @@ export class GenericDropdown {
     const root = this.renderMode() === 'inline'
       ? (this.inlineMenuRoot ?? document)
       : this.overlayRef?.overlayElement;
-    const list = root?.querySelectorAll('a[role="menuitem"]');
+    const list = root?.querySelectorAll(`a[role="${ this.itemRole() }"]`);
     this.menuItems = list ? (Array.from(list) as HTMLElement[]) : [];
     if (this.menuItems.length) {
       this.setActive(0);
@@ -313,7 +333,6 @@ export class GenericDropdown {
     this.menuItems.forEach((el, i) => {
       (el as HTMLElement).tabIndex = i === idx ? 0 : -1;
       if (i === idx) (el as HTMLElement).focus();
-      el.setAttribute('aria-selected', i === idx ? 'true' : 'false');
     });
   }
 

--- a/src/app/shared/components/generic-link/generic-link.spec.ts
+++ b/src/app/shared/components/generic-link/generic-link.spec.ts
@@ -102,6 +102,24 @@ describe('GenericLink', () => {
     expect(anchor.getAttribute('href')).toContain('/acerca-de-mi?draftDomain=pamelabetancourt.com&debugWorkspace=true');
   });
 
+  it('should carry the active draftDomain onto internal hrefs that omit it', () => {
+    fixture.componentRef.setInput('config', {
+      id: 'spec',
+      href: '/servicios',
+      text: 'Servicios',
+    });
+    fixture.detectChanges();
+
+    const anchor = fixture.nativeElement.querySelector('a') as HTMLAnchorElement;
+
+    expect(component.href()).toBe('/servicios?draftDomain=pamelabetancourt.com&debugWorkspace=true');
+    expect(component.routerLinkQueryParams()).toEqual({
+      draftDomain: 'pamelabetancourt.com',
+      debugWorkspace: 'true',
+    });
+    expect(anchor.getAttribute('href')).toContain('/servicios?draftDomain=pamelabetancourt.com&debugWorkspace=true');
+  });
+
   it('should normalize encoded unicode internal hrefs without double-encoding them', () => {
     fixture.componentRef.setInput('config', {
       id: 'spec',

--- a/src/app/shared/interceptors/draft-config.interceptor.ts
+++ b/src/app/shared/interceptors/draft-config.interceptor.ts
@@ -10,7 +10,7 @@ const CONFIG_ENDPOINTS = new Set([
 ]);
 
 const getDraftUrl = (endpoint: string, params: URLSearchParams): string => {
-    const base = String(environment.drafts.basePath ?? 'assets/drafts').replace(/^\/+/, '');
+    const base = String(environment.drafts.basePath ?? 'drafts').replace(/^\/+/, '');
     const domain = String(params.get('domain') ?? '').trim();
     const pageId = String(params.get('pageId') ?? '').trim();
 

--- a/src/app/shared/services/analytics.service.spec.ts
+++ b/src/app/shared/services/analytics.service.spec.ts
@@ -151,6 +151,54 @@ describe('AnalyticsService', () => {
     expect(post).not.toHaveBeenCalled();
   });
 
+  it('does not log console errors when geolocation access is denied', async () => {
+    const getCurrentPosition = spyOn(navigator.geolocation, 'getCurrentPosition').and.callFake(
+      (_success: PositionCallback, error?: PositionErrorCallback | null) => {
+        error?.({
+          code: 1,
+          message: 'Permission denied',
+          PERMISSION_DENIED: 1,
+          POSITION_UNAVAILABLE: 2,
+          TIMEOUT: 3,
+        } as GeolocationPositionError);
+      }
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: RuntimeConfigService,
+          useValue: {
+            appIdentifier: () => 'zoolandingpagecommx',
+            isAnalyticsEnabled: () => true,
+            isDebugMode: () => false,
+            analyticsConsentMode: () => 'none',
+            resolveStorageKey: (slot: string) => slot,
+            track: () => ['geolocationLatitude', 'geolocationLongitude', 'geolocationAccuracy'],
+          },
+        },
+        {
+          provide: HttpClient,
+          useValue: {
+            post: jasmine.createSpy('post').and.returnValue(of({ ok: true })),
+          } as any,
+        },
+      ],
+    });
+
+    const svc = TestBed.inject(AnalyticsService);
+    const consoleError = spyOn(console, 'error');
+
+    svc.initializeRuntimeState();
+    const data = await svc.getAllDataFromUser();
+
+    expect(getCurrentPosition).toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(data?.geolocationLatitude).toBeUndefined();
+    expect(data?.geolocationLongitude).toBeUndefined();
+    expect(data?.geolocationAccuracy).toBeUndefined();
+  });
+
   it('does not bump remote quick stats when analytics is disabled', () => {
     const quickStats = jasmine.createSpyObj<QuickStatsService>('QuickStatsService', ['inc', 'getNumber']);
     quickStats.inc.and.returnValue(of({ ok: true }));

--- a/src/app/shared/services/analytics.service.ts
+++ b/src/app/shared/services/analytics.service.ts
@@ -579,8 +579,8 @@ export class AnalyticsService {
               if (trackOptions.includes('geolocationLongitude')) data['geolocationLongitude'] = position.coords.longitude;
               if (trackOptions.includes('geolocationAccuracy')) data['geolocationAccuracy'] = position.coords.accuracy;
             },
-            (error) => {
-              console.error('Error getting geolocation:', error);
+            () => {
+              // Geolocation is optional analytics enrichment. Ignore denied or unavailable access.
             }
           );
         }

--- a/src/app/shared/services/config-bootstrap.service.spec.ts
+++ b/src/app/shared/services/config-bootstrap.service.spec.ts
@@ -79,8 +79,32 @@ const createComponentsPayload = (components: Record<string, TComponentPayloadEnt
 
 describe('ConfigBootstrapService', () => {
     let service: ConfigBootstrapService;
+    let source: jasmine.SpyObj<ConfigSourceService>;
+    let i18n: jasmine.SpyObj<I18nService>;
+    let language: jasmine.SpyObj<LanguageService>;
+    let store: ConfigStoreService;
 
     beforeEach(() => {
+        source = jasmine.createSpyObj<ConfigSourceService>('ConfigSourceService', [
+            'loadPageConfig',
+            'loadComponents',
+            'loadVariables',
+            'loadCombos',
+            'loadI18n',
+        ]);
+        i18n = jasmine.createSpyObj<I18nService>('I18nService', [
+            'disableAutoLoad',
+            'setLoader',
+            'prefetch',
+            'setTranslations',
+            'enableAutoLoad',
+        ]);
+        language = jasmine.createSpyObj<LanguageService>('LanguageService', [
+            'currentLanguage',
+            'configureLanguages',
+        ]);
+        language.currentLanguage.and.returnValue('es');
+
         TestBed.configureTestingModule({
             providers: [
                 ConfigBootstrapService,
@@ -89,7 +113,7 @@ describe('ConfigBootstrapService', () => {
                 { provide: PLATFORM_ID, useValue: 'browser' },
                 {
                     provide: ConfigSourceService,
-                    useValue: {},
+                    useValue: source,
                 },
                 {
                     provide: DomainResolverService,
@@ -99,20 +123,11 @@ describe('ConfigBootstrapService', () => {
                 },
                 {
                     provide: I18nService,
-                    useValue: {
-                        disableAutoLoad: () => { },
-                        setLoader: () => { },
-                        prefetch: async () => { },
-                        setTranslations: () => { },
-                        enableAutoLoad: () => { },
-                    },
+                    useValue: i18n,
                 },
                 {
                     provide: LanguageService,
-                    useValue: {
-                        currentLanguage: () => 'es',
-                        configureLanguages: () => { },
-                    },
+                    useValue: language,
                 },
                 {
                     provide: StructuredDataService,
@@ -124,6 +139,81 @@ describe('ConfigBootstrapService', () => {
         });
 
         service = TestBed.inject(ConfigBootstrapService);
+        store = TestBed.inject(ConfigStoreService);
+    });
+
+    it('does not block bootstrap completion on the fallback language prefetch', async () => {
+        let resolveFallback!: (payload: unknown) => void;
+
+        store.setSiteConfig(createSiteConfig());
+        source.loadPageConfig.and.resolveTo({
+            version: 1,
+            pageId: 'default',
+            domain: 'zoolandingpage.com.mx',
+            rootIds: ['landingPage'],
+            modalRootIds: [],
+        });
+        source.loadComponents.and.resolveTo(createComponentsPayload({
+            landingPage: {
+                id: 'landingPage',
+                type: 'container',
+                config: { tag: 'main', components: [] },
+            },
+        }));
+        source.loadVariables.and.resolveTo({
+            version: 1,
+            pageId: 'default',
+            domain: 'zoolandingpage.com.mx',
+            variables: {},
+        });
+        source.loadCombos.and.resolveTo(null);
+        source.loadI18n.and.callFake(async (_domain: string, _pageId: string, langCode: string) => {
+            if (langCode === 'es') {
+                return {
+                    version: 1,
+                    pageId: 'default',
+                    domain: 'zoolandingpage.com.mx',
+                    lang: 'es',
+                    dictionary: {},
+                };
+            }
+
+            return await new Promise((resolve) => {
+                resolveFallback = resolve;
+            }) as any;
+        });
+
+        await expectAsync(service.load({
+            domain: 'zoolandingpage.com.mx',
+            pageId: 'default',
+            lang: 'es',
+        })).toBeResolvedTo(jasmine.objectContaining({
+            domain: 'zoolandingpage.com.mx',
+            pageId: 'default',
+        }));
+
+        expect(source.loadI18n.calls.allArgs()).toEqual([
+            ['zoolandingpage.com.mx', 'default', 'es'],
+            ['zoolandingpage.com.mx', 'default', 'en'],
+        ]);
+        expect(i18n.setTranslations).toHaveBeenCalledWith('es', {}, {
+            cache: true,
+            applyIfCurrent: true,
+        });
+
+        resolveFallback({
+            version: 1,
+            pageId: 'default',
+            domain: 'zoolandingpage.com.mx',
+            lang: 'en',
+            dictionary: {},
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(i18n.setTranslations).toHaveBeenCalledWith('en', {}, {
+            cache: true,
+            applyIfCurrent: false,
+        });
     });
 
     it('reports missing modal config when a payload references a modal-owned dialog', () => {

--- a/src/app/shared/services/config-bootstrap.service.ts
+++ b/src/app/shared/services/config-bootstrap.service.ts
@@ -327,12 +327,7 @@ export class ConfigBootstrapService {
         );
 
         if (fallbackLang) {
-            const secondary = await this.loadI18n(domain, pageId, fallbackLang);
-            this.i18n.setTranslations(
-                secondary?.lang ?? fallbackLang,
-                secondary?.dictionary ?? {},
-                { cache: true, applyIfCurrent: false }
-            );
+            void this.prefetchFallbackLanguage(domain, pageId, fallbackLang);
         }
 
         this.i18n.enableAutoLoad();
@@ -594,6 +589,19 @@ export class ConfigBootstrapService {
                 return {};
             },
             { clearCache: true, reload: false }
+        );
+    }
+
+    private async prefetchFallbackLanguage(domain: string, pageId: string, lang: string): Promise<void> {
+        const payload = await this.loadI18n(domain, pageId, lang);
+        if (!payload) {
+            return;
+        }
+
+        this.i18n.setTranslations(
+            payload.lang ?? lang,
+            payload.dictionary ?? {},
+            { cache: true, applyIfCurrent: false }
         );
     }
 }

--- a/src/app/shared/services/config-source.service.spec.ts
+++ b/src/app/shared/services/config-source.service.spec.ts
@@ -16,6 +16,7 @@ import { LanguageService } from './language.service';
 
 describe('ConfigSourceService', () => {
     let originalDraftsEnabled: boolean;
+    const originalUrl = window.location.pathname + window.location.search + window.location.hash;
 
     const themePalette = {
         bgColor: '#ffffff',
@@ -175,6 +176,7 @@ describe('ConfigSourceService', () => {
 
     afterEach(() => {
         (environment.drafts as { enabled: boolean }).enabled = originalDraftsEnabled;
+        window.history.replaceState({}, '', originalUrl);
     });
 
     it('returns null variables from the bundle without calling the legacy endpoint', async () => {
@@ -237,5 +239,21 @@ describe('ConfigSourceService', () => {
 
         expect(result).toEqual(bundledVariables);
         expect(api.getVariables).not.toHaveBeenCalled();
+    });
+
+    it('warms a target route so the next bundle-backed page load reuses the cached runtime request', async () => {
+        const service = TestBed.inject(ConfigSourceService);
+        const api = TestBed.inject(ConfigApiService) as jasmine.SpyObj<ConfigApiService>;
+
+        await service.prefetchRoute('alecfest-voliii.zoolandingpage.com.mx', {
+            pageId: 'default',
+            lang: 'es',
+            path: '/servicios',
+        });
+
+        window.history.replaceState({}, '', '/servicios');
+        await service.loadComponents('alecfest-voliii.zoolandingpage.com.mx', 'default');
+
+        expect(api.getRuntimeBundle.calls.count()).toBe(1);
     });
 });

--- a/src/app/shared/services/config-source.service.ts
+++ b/src/app/shared/services/config-source.service.ts
@@ -147,10 +147,20 @@ export class ConfigSourceService {
         return [domain.trim().toLowerCase(), pageId.trim(), lang.trim().toLowerCase(), this.normalizePath(path)].join('::');
     }
 
+    private resolveRuntimeBundlePath(pathOverride?: string): string {
+        const explicitPath = String(pathOverride ?? '').trim();
+        if (explicitPath) {
+            return this.normalizePath(explicitPath);
+        }
+
+        return this.resolveActivePath();
+    }
+
     private async loadRuntimeBundle(domain: string, opts?: {
         pageId?: string;
         lang?: string;
         forceRefresh?: boolean;
+        path?: string;
     }): Promise<TRuntimeBundlePayload | null> {
         const normalizedDomain = String(domain ?? '').trim();
         if (!normalizedDomain) {
@@ -159,7 +169,7 @@ export class ConfigSourceService {
 
         const pageId = String(opts?.pageId ?? '').trim();
         const lang = this.resolveLanguage(opts?.lang);
-        const currentPath = this.resolveActivePath();
+        const currentPath = this.resolveRuntimeBundlePath(opts?.path);
         const requestedKey = this.createRuntimeBundleCacheKey(normalizedDomain, pageId, lang, currentPath);
 
         if (opts?.forceRefresh) {
@@ -207,6 +217,7 @@ export class ConfigSourceService {
     private async tryLoadRuntimeBundle(domain: string, opts?: {
         pageId?: string;
         lang?: string;
+        path?: string;
     }): Promise<TRuntimeBundlePayload | null> {
         try {
             return await this.loadRuntimeBundle(domain, opts);
@@ -255,6 +266,35 @@ export class ConfigSourceService {
 
     loadI18n(domain: string, pageId: string, lang: string): Promise<TI18nPayload | null> {
         return this.source.loadI18n(domain, pageId, lang);
+    }
+
+    async prefetchRoute(domain: string, opts?: { pageId?: string; lang?: string; path?: string }): Promise<void> {
+        const normalizedDomain = String(domain ?? '').trim();
+        if (!normalizedDomain) {
+            return;
+        }
+
+        if (environment.drafts.enabled) {
+            await this.drafts.prefetchSiteConfig(normalizedDomain);
+
+            const pageId = String(opts?.pageId ?? '').trim();
+            if (!pageId) {
+                return;
+            }
+
+            await this.drafts.prefetchPagePayloads({
+                domain: normalizedDomain,
+                pageId,
+                lang: opts?.lang,
+            });
+            return;
+        }
+
+        await this.tryLoadRuntimeBundle(normalizedDomain, {
+            pageId: opts?.pageId,
+            lang: opts?.lang,
+            path: opts?.path,
+        });
     }
 
     loadDebugWorkspacePageConfig(): Promise<TPageConfigPayload | null> {

--- a/src/app/shared/services/draft-config-loader.service.spec.ts
+++ b/src/app/shared/services/draft-config-loader.service.spec.ts
@@ -65,8 +65,10 @@ describe('DraftConfigLoaderService', () => {
             .toBeResolvedTo(jasmine.objectContaining({ lang: 'es' }));
 
         expect(fetchSpy.calls.allArgs().map((args) => String(args[0]))).toEqual([
-            'assets/drafts/zoolandingpage.com.mx/default/i18n/es-MX.json',
-            'assets/drafts/zoolandingpage.com.mx/default/i18n/es.json',
+            'drafts/zoolandingpage.com.mx/i18n/es-MX.json',
+            'drafts/zoolandingpage.com.mx/default/i18n/es-MX.json',
+            'drafts/zoolandingpage.com.mx/i18n/es.json',
+            'drafts/zoolandingpage.com.mx/default/i18n/es.json',
         ]);
     });
 
@@ -74,7 +76,7 @@ describe('DraftConfigLoaderService', () => {
         spyOn(window, 'fetch').and.callFake((input: RequestInfo | URL) => {
             const url = String(input);
 
-            if (url.endsWith('assets/drafts/zoolandingpage.com.mx/components.json')) {
+            if (url.endsWith('drafts/zoolandingpage.com.mx/components.json')) {
                 return Promise.resolve(createJsonResponse(createComponentsPayload({
                     siteHeader: {
                         id: 'siteHeader',
@@ -89,7 +91,7 @@ describe('DraftConfigLoaderService', () => {
                 }, { pageId: 'allPages' })));
             }
 
-            if (url.endsWith('assets/drafts/zoolandingpage.com.mx/default/components.json')) {
+            if (url.endsWith('drafts/zoolandingpage.com.mx/default/components.json')) {
                 return Promise.resolve(createJsonResponse(createComponentsPayload({
                     landingPage: {
                         id: 'landingPage',
@@ -137,5 +139,82 @@ describe('DraftConfigLoaderService', () => {
                 },
             ],
         });
+    });
+
+    it('reuses a warm site-config response within the in-memory draft cache window', async () => {
+        const fetchSpy = spyOn(window, 'fetch').and.callFake((input: RequestInfo | URL) => {
+            const url = String(input);
+
+            if (url.endsWith('drafts/zoolandingpage.com.mx/site-config.json')) {
+                return Promise.resolve(createJsonResponse({
+                    version: 1,
+                    domain: 'zoolandingpage.com.mx',
+                    defaultPageId: 'default',
+                    routes: [{ path: '/', pageId: 'default' }],
+                    site: {
+                        appIdentity: {
+                            identifier: 'zoolandingpagecommx',
+                            name: 'Zoo Landing Page',
+                        },
+                        theme: {
+                            palettes: {
+                                light: {
+                                    bgColor: '#ffffff',
+                                    textColor: '#111111',
+                                    titleColor: '#111111',
+                                    linkColor: '#111111',
+                                    accentColor: '#111111',
+                                    secondaryBgColor: '#f5f5f5',
+                                    secondaryTextColor: '#333333',
+                                    secondaryTitleColor: '#111111',
+                                    secondaryLinkColor: '#111111',
+                                    secondaryAccentColor: '#111111',
+                                    successColor: '#198754',
+                                    onSuccessColor: '#ffffff',
+                                    errorColor: '#dc3545',
+                                    onErrorColor: '#ffffff',
+                                    warningColor: '#f59e0b',
+                                    onWarningColor: '#111111',
+                                    infoColor: '#0d6efd',
+                                    onInfoColor: '#ffffff',
+                                },
+                                dark: {
+                                    bgColor: '#111111',
+                                    textColor: '#f5f5f5',
+                                    titleColor: '#f5f5f5',
+                                    linkColor: '#f5f5f5',
+                                    accentColor: '#f5f5f5',
+                                    secondaryBgColor: '#1f1f1f',
+                                    secondaryTextColor: '#e5e5e5',
+                                    secondaryTitleColor: '#f5f5f5',
+                                    secondaryLinkColor: '#f5f5f5',
+                                    secondaryAccentColor: '#f5f5f5',
+                                    successColor: '#32d583',
+                                    onSuccessColor: '#052e1c',
+                                    errorColor: '#ff6b6b',
+                                    onErrorColor: '#3b0a10',
+                                    warningColor: '#f5b942',
+                                    onWarningColor: '#3a2400',
+                                    infoColor: '#58a6ff',
+                                    onInfoColor: '#041b44',
+                                },
+                            },
+                        },
+                        i18n: {
+                            defaultLanguage: 'es',
+                            supportedLanguages: ['es'],
+                        },
+                    },
+                }));
+            }
+
+            return Promise.reject(new Error(`Unexpected fetch: ${ url }`));
+        });
+
+        await service.loadSiteConfig('zoolandingpage.com.mx');
+        await service.loadSiteConfig('zoolandingpage.com.mx');
+
+        expect(service.hasWarmSiteConfig('zoolandingpage.com.mx')).toBeTrue();
+        expect(fetchSpy.calls.count()).toBe(1);
     });
 });

--- a/src/app/shared/services/draft-config-loader.service.ts
+++ b/src/app/shared/services/draft-config-loader.service.ts
@@ -19,9 +19,62 @@ import {
 import { environment } from '@/environments/environment';
 import { Injectable } from '@angular/core';
 
+type TDraftCacheEntry<T> = {
+    readonly expiresAt: number;
+    readonly value: Promise<T | null>;
+};
+
 @Injectable({ providedIn: 'root' })
 export class DraftConfigLoaderService {
-    private readonly debugWorkspaceBase = `${ String(environment.drafts.basePath ?? 'assets/drafts').replace(/\/$/, '') }/_debug/debug-workspace`;
+    private readonly draftCacheTtlMs = 5000;
+    private readonly debugWorkspaceBase = `${ String(environment.drafts.basePath ?? 'drafts').replace(/\/$/, '') }/_debug/debug-workspace`;
+    private readonly siteConfigCache = new Map<string, TDraftCacheEntry<TDraftSiteConfigPayload>>();
+    private readonly pageConfigCache = new Map<string, TDraftCacheEntry<TPageConfigPayload>>();
+    private readonly componentsCache = new Map<string, TDraftCacheEntry<TComponentsPayload>>();
+    private readonly variablesCache = new Map<string, TDraftCacheEntry<TVariablesPayload>>();
+    private readonly combosCache = new Map<string, TDraftCacheEntry<TAngoraCombosPayload>>();
+    private readonly i18nCache = new Map<string, TDraftCacheEntry<TI18nPayload>>();
+
+    private createDomainCacheKey(domain?: string): string {
+        return String(domain ?? '').trim().toLowerCase();
+    }
+
+    private createPageCacheKey(domain?: string, pageId?: string): string {
+        return `${ this.createDomainCacheKey(domain) }::${ String(pageId ?? '').trim() }`;
+    }
+
+    private createI18nCacheKey(domain?: string, pageId?: string, lang?: string): string {
+        return `${ this.createPageCacheKey(domain, pageId) }::${ String(lang ?? '').trim().toLowerCase() }`;
+    }
+
+    private isWarmCacheEntry<T>(cache: Map<string, TDraftCacheEntry<T>>, key: string): boolean {
+        const cached = cache.get(key);
+        return !!cached && cached.expiresAt > Date.now();
+    }
+
+    private getCachedValue<T>(
+        cache: Map<string, TDraftCacheEntry<T>>,
+        key: string,
+        loader: () => Promise<T | null>,
+    ): Promise<T | null> {
+        const now = Date.now();
+        const cached = cache.get(key);
+        if (cached && cached.expiresAt > now) {
+            return cached.value;
+        }
+
+        const value = loader().catch((error) => {
+            cache.delete(key);
+            throw error;
+        });
+
+        cache.set(key, {
+            expiresAt: now + this.draftCacheTtlMs,
+            value,
+        });
+
+        return value;
+    }
 
     private isRecord(value: unknown): value is Record<string, unknown> {
         return !!value && typeof value === 'object' && !Array.isArray(value);
@@ -44,7 +97,7 @@ export class DraftConfigLoaderService {
     }
 
     private getDomainBase(domain?: string): string {
-        const base = String(environment.drafts.basePath ?? 'assets/drafts').replace(/\/$/, '');
+        const base = String(environment.drafts.basePath ?? 'drafts').replace(/\/$/, '');
         const d = String(domain ?? '').trim();
         if (!d) {
             return '';
@@ -202,15 +255,56 @@ export class DraftConfigLoaderService {
         });
     }
 
+    hasWarmSiteConfig(domain?: string): boolean {
+        return this.isWarmCacheEntry(this.siteConfigCache, this.createDomainCacheKey(domain));
+    }
+
+    hasWarmPagePayloads(opts?: { domain?: string; pageId?: string; lang?: string }): boolean {
+        const pageKey = this.createPageCacheKey(opts?.domain, opts?.pageId);
+        const langKey = this.createI18nCacheKey(opts?.domain, opts?.pageId, opts?.lang);
+
+        return this.isWarmCacheEntry(this.pageConfigCache, pageKey)
+            && this.isWarmCacheEntry(this.componentsCache, pageKey)
+            && this.isWarmCacheEntry(this.variablesCache, pageKey)
+            && this.isWarmCacheEntry(this.combosCache, pageKey)
+            && (!String(opts?.lang ?? '').trim() || this.isWarmCacheEntry(this.i18nCache, langKey));
+    }
+
+    async prefetchSiteConfig(domain?: string): Promise<void> {
+        await this.loadSiteConfig(domain);
+    }
+
+    async prefetchPagePayloads(opts?: { domain?: string; pageId?: string; lang?: string }): Promise<void> {
+        const domain = String(opts?.domain ?? '').trim();
+        const pageId = String(opts?.pageId ?? '').trim();
+        const lang = String(opts?.lang ?? '').trim();
+
+        if (!domain || !pageId) {
+            return;
+        }
+
+        await this.prefetchSiteConfig(domain);
+        await Promise.all([
+            this.loadPageConfig(domain, pageId),
+            this.loadComponents(domain, pageId),
+            this.loadVariables(domain, pageId),
+            this.loadAngoraCombos(domain, pageId),
+            lang ? this.loadI18n(domain, pageId, lang) : Promise.resolve(null),
+        ]);
+    }
+
     async loadSiteConfig(domain?: string): Promise<TDraftSiteConfigPayload | null> {
         const domainBase = this.getDomainBase(domain);
         if (!domainBase) {
             return null;
         }
 
-        const url = `${ domainBase }/site-config.json`;
-        const payload = await this.getJson<TDraftSiteConfigPayload>(url);
-        return isDraftSiteConfigPayload(payload) ? payload : null;
+        const key = this.createDomainCacheKey(domain);
+        return this.getCachedValue(this.siteConfigCache, key, async () => {
+            const url = `${ domainBase }/site-config.json`;
+            const payload = await this.getJson<TDraftSiteConfigPayload>(url);
+            return isDraftSiteConfigPayload(payload) ? payload : null;
+        });
     }
 
     async loadPageConfig(domain?: string, pageId?: string): Promise<TPageConfigPayload | null> {
@@ -219,9 +313,12 @@ export class DraftConfigLoaderService {
             return null;
         }
 
-        const url = `${ draftBase }/page-config.json`;
-        const payload = await this.getJson<TPageConfigPayload>(url);
-        return isPageConfigPayload(payload) ? payload : null;
+        const key = this.createPageCacheKey(domain, pageId);
+        return this.getCachedValue(this.pageConfigCache, key, async () => {
+            const url = `${ draftBase }/page-config.json`;
+            const payload = await this.getJson<TPageConfigPayload>(url);
+            return isPageConfigPayload(payload) ? payload : null;
+        });
     }
 
     async loadComponents(domain?: string, pageId?: string): Promise<TComponentsPayload | null> {
@@ -233,12 +330,15 @@ export class DraftConfigLoaderService {
             return null;
         }
 
-        const [sitePayload, pagePayload] = await Promise.all([
-            this.loadComponentsPayload(`${ domainBase }/components.json`),
-            this.loadComponentsPayload(`${ draftBase }/components.json`),
-        ]);
+        const key = this.createPageCacheKey(domain, pageId);
+        return this.getCachedValue(this.componentsCache, key, async () => {
+            const [sitePayload, pagePayload] = await Promise.all([
+                this.loadComponentsPayload(`${ domainBase }/components.json`),
+                this.loadComponentsPayload(`${ draftBase }/components.json`),
+            ]);
 
-        return this.mergeComponentsPayloads(normalizedDomain, normalizedPageId, [sitePayload, pagePayload]);
+            return this.mergeComponentsPayloads(normalizedDomain, normalizedPageId, [sitePayload, pagePayload]);
+        });
     }
 
     async loadVariables(domain?: string, pageId?: string): Promise<TVariablesPayload | null> {
@@ -250,19 +350,22 @@ export class DraftConfigLoaderService {
             return null;
         }
 
-        const [sitePayload, pagePayload] = await Promise.all([
-            this.getJson<TVariablesPayload>(`${ domainBase }/variables.json`),
-            this.getJson<TVariablesPayload>(`${ draftBase }/variables.json`),
-        ]);
+        const key = this.createPageCacheKey(domain, pageId);
+        return this.getCachedValue(this.variablesCache, key, async () => {
+            const [sitePayload, pagePayload] = await Promise.all([
+                this.getJson<TVariablesPayload>(`${ domainBase }/variables.json`),
+                this.getJson<TVariablesPayload>(`${ draftBase }/variables.json`),
+            ]);
 
-        return this.mergeVariablesPayloads(
-            normalizedDomain,
-            normalizedPageId,
-            [
-                isVariablesPayload(sitePayload) ? sitePayload : null,
-                isVariablesPayload(pagePayload) ? pagePayload : null,
-            ],
-        );
+            return this.mergeVariablesPayloads(
+                normalizedDomain,
+                normalizedPageId,
+                [
+                    isVariablesPayload(sitePayload) ? sitePayload : null,
+                    isVariablesPayload(pagePayload) ? pagePayload : null,
+                ],
+            );
+        });
     }
 
     async loadAngoraCombos(domain?: string, pageId?: string): Promise<TAngoraCombosPayload | null> {
@@ -274,19 +377,22 @@ export class DraftConfigLoaderService {
             return null;
         }
 
-        const [sitePayload, pagePayload] = await Promise.all([
-            this.getJson<TAngoraCombosPayload>(`${ domainBase }/angora-combos.json`),
-            this.getJson<TAngoraCombosPayload>(`${ draftBase }/angora-combos.json`),
-        ]);
+        const key = this.createPageCacheKey(domain, pageId);
+        return this.getCachedValue(this.combosCache, key, async () => {
+            const [sitePayload, pagePayload] = await Promise.all([
+                this.getJson<TAngoraCombosPayload>(`${ domainBase }/angora-combos.json`),
+                this.getJson<TAngoraCombosPayload>(`${ draftBase }/angora-combos.json`),
+            ]);
 
-        return this.mergeCombosPayloads(
-            normalizedDomain,
-            normalizedPageId,
-            [
-                isAngoraCombosPayload(sitePayload) ? sitePayload : null,
-                isAngoraCombosPayload(pagePayload) ? pagePayload : null,
-            ],
-        );
+            return this.mergeCombosPayloads(
+                normalizedDomain,
+                normalizedPageId,
+                [
+                    isAngoraCombosPayload(sitePayload) ? sitePayload : null,
+                    isAngoraCombosPayload(pagePayload) ? pagePayload : null,
+                ],
+            );
+        });
     }
 
     async loadDebugWorkspacePageConfig(): Promise<TPageConfigPayload | null> {
@@ -310,24 +416,27 @@ export class DraftConfigLoaderService {
             return null;
         }
 
-        const candidates = getLocaleCandidates(lang);
+        const key = this.createI18nCacheKey(domain, pageId, lang);
+        return this.getCachedValue(this.i18nCache, key, async () => {
+            const candidates = getLocaleCandidates(lang);
 
-        for (const candidate of candidates) {
-            const [sitePayload, pagePayload] = await Promise.all([
-                this.getJson<TI18nPayload>(`${ domainBase }/i18n/${ encodeURIComponent(candidate) }.json`),
-                this.getJson<TI18nPayload>(`${ base }/i18n/${ encodeURIComponent(candidate) }.json`),
-            ]);
+            for (const candidate of candidates) {
+                const [sitePayload, pagePayload] = await Promise.all([
+                    this.getJson<TI18nPayload>(`${ domainBase }/i18n/${ encodeURIComponent(candidate) }.json`),
+                    this.getJson<TI18nPayload>(`${ base }/i18n/${ encodeURIComponent(candidate) }.json`),
+                ]);
 
-            const merged = this.mergeI18nPayloads(domain, pageId, candidate, [
-                isI18nPayload(sitePayload) ? sitePayload : null,
-                isI18nPayload(pagePayload) ? pagePayload : null,
-            ]);
+                const merged = this.mergeI18nPayloads(domain, pageId, candidate, [
+                    isI18nPayload(sitePayload) ? sitePayload : null,
+                    isI18nPayload(pagePayload) ? pagePayload : null,
+                ]);
 
-            if (merged) {
-                return merged;
+                if (merged) {
+                    return merged;
+                }
             }
-        }
 
-        return null;
+            return null;
+        });
     }
 }

--- a/src/app/shared/services/draft-runtime.service.ts
+++ b/src/app/shared/services/draft-runtime.service.ts
@@ -9,7 +9,7 @@ import { DomainResolverService } from './domain-resolver.service';
 import { DraftRegistryService, TDraftRegistryEntry } from './draft-registry.service';
 import { RuntimeConfigService } from './runtime-config.service';
 
-export const DRAFT_RUNTIME_STICKY_QUERY_PARAMS = ['debugWorkspace'] as const;
+export const DRAFT_RUNTIME_STICKY_QUERY_PARAMS = ['draftDomain', 'debugWorkspace'] as const;
 const INTERNAL_DEBUG_DRAFT_DOMAIN = '_debug';
 const INTERNAL_DEBUG_DRAFT_PAGE_ID = 'debug-workspace';
 

--- a/src/app/shared/utility/event-handler/handlers/ui.handlers.spec.ts
+++ b/src/app/shared/utility/event-handler/handlers/ui.handlers.spec.ts
@@ -118,6 +118,15 @@ describe('navigateToUrlHandler', () => {
         expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/acerca-de-mi?draftDomain=pamelabetancourt.com&debugWorkspace=true');
     });
 
+    it('should preserve the active draftDomain on internal navigation when the target omits it', async () => {
+        const handler = TestBed.runInInjectionContext(() => navigateToUrlHandler());
+
+        handler.handle(context, ['/servicios']);
+        await Promise.resolve();
+
+        expect(router.navigateByUrl).toHaveBeenCalledOnceWith('/servicios?draftDomain=pamelabetancourt.com&debugWorkspace=true');
+    });
+
     it('should avoid double-encoding unicode internal routes', async () => {
         const handler = TestBed.runInInjectionContext(() => navigateToUrlHandler());
 
@@ -194,6 +203,7 @@ describe('openModalHandler', () => {
 
 describe('whatsapp handlers', () => {
     let analytics: jasmine.SpyObj<AnalyticsService>;
+    let language: LanguageService;
     let variables: VariableStoreService;
     let context: EventExecutionContext;
     let openSpy: jasmine.Spy<(url?: string | URL, target?: string, features?: string) => Window | null>;
@@ -211,6 +221,8 @@ describe('whatsapp handlers', () => {
             ]
         });
 
+        language = TestBed.inject(LanguageService);
+        language.configureLanguages(['es'], { defaultLanguage: 'es', requestedLanguage: 'es' });
         variables = TestBed.inject(VariableStoreService);
         variables.setPayload({
             version: 1,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -12,6 +12,6 @@ export const environment: TEnvironment = {
   configApiUrl: 'https://api.zoolandingpage.com.mx',
   drafts: {
     enabled: false,
-    basePath: 'assets/drafts'
+    basePath: 'drafts'
   }
 } as const;

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -13,6 +13,6 @@ export const environment: TEnvironment = {
   configApiUrl: 'https://nxk92p5uzc.execute-api.us-east-1.amazonaws.com',
   drafts: {
     enabled: true,
-    basePath: 'assets/drafts',
+    basePath: 'drafts',
   }
 } as const;

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,8 @@ import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
 const browserDistFolder = join(import.meta.dirname, '../browser');
+const DRAFTS_FOLDER_NAME = 'drafts';
+const LOCAL_NOTE_FOLDER_NAMES = new Set(['ai_notes', 'findings', 'errors-reports']);
 
 type TDraftRegistryEntry = {
   readonly domain: string;
@@ -25,8 +27,8 @@ function isDirectory(path: string): boolean {
 
 function resolveDraftsFolder(): string | null {
   const candidates = [
-    join(process.cwd(), 'public', 'assets', 'drafts'),
-    join(browserDistFolder, 'assets', 'drafts'),
+    join(process.cwd(), DRAFTS_FOLDER_NAME),
+    join(browserDistFolder, DRAFTS_FOLDER_NAME),
   ];
 
   return candidates.find((candidate) => existsSync(candidate) && isDirectory(candidate)) ?? null;
@@ -47,6 +49,8 @@ function listDraftRegistryEntries(): readonly TDraftRegistryEntry[] {
     const domainFolder = join(draftsFolder, domain);
     return readdirSync(domainFolder, { withFileTypes: true })
       .filter((entry) => entry.isDirectory())
+      .filter((entry) => !LOCAL_NOTE_FOLDER_NAMES.has(entry.name))
+      .filter((entry) => existsSync(join(domainFolder, entry.name, 'page-config.json')))
       .map((entry) => ({
         domain,
         pageId: entry.name,
@@ -73,6 +77,24 @@ const angularApp = new AngularNodeAppEngine();
 app.get('/api/debug/drafts', (_req, res) => {
   res.json({ drafts: listDraftRegistryEntries() });
 });
+
+const draftsFolder = resolveDraftsFolder();
+
+if (draftsFolder) {
+  app.use('/drafts', (req, res, next) => {
+    const segments = req.path.split('/').filter(Boolean);
+    if (segments.some((segment) => LOCAL_NOTE_FOLDER_NAMES.has(segment)) || req.path.endsWith('.md')) {
+      res.sendStatus(404);
+      return;
+    }
+
+    next();
+  }, express.static(draftsFolder, {
+    maxAge: '0',
+    index: false,
+    redirect: false,
+  }));
+}
 
 /**
  * Serve static files from /browser

--- a/src/server.ts
+++ b/src/server.ts
@@ -83,7 +83,7 @@ const draftsFolder = resolveDraftsFolder();
 if (draftsFolder) {
   app.use('/drafts', (req, res, next) => {
     const segments = req.path.split('/').filter(Boolean);
-    if (segments.some((segment) => LOCAL_NOTE_FOLDER_NAMES.has(segment)) || req.path.endsWith('.md')) {
+    if (segments.some((segment) => LOCAL_NOTE_FOLDER_NAMES.has(segment)) || req.path.toLowerCase().endsWith('.md')) {
       res.sendStatus(404);
       return;
     }

--- a/tools/config-draft-sync.mjs
+++ b/tools/config-draft-sync.mjs
@@ -2,7 +2,8 @@ import { existsSync } from 'node:fs';
 import { mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
-const DEFAULT_DRAFTS_ROOT = path.resolve('public', 'assets', 'drafts');
+const DEFAULT_DRAFTS_ROOT = path.resolve('drafts');
+const LOCAL_DRAFT_CONTEXT_FOLDERS = new Set(['ai_notes', 'findings', 'errors-reports']);
 
 function parseArgs(rawArgs) {
   const parsed = {};
@@ -53,6 +54,9 @@ async function walkJsonFiles(rootDir) {
   for (const entry of entries) {
     const fullPath = path.join(rootDir, entry.name);
     if (entry.isDirectory()) {
+      if (LOCAL_DRAFT_CONTEXT_FOLDERS.has(entry.name)) {
+        continue;
+      }
       files.push(...(await walkJsonFiles(fullPath)));
       continue;
     }
@@ -62,6 +66,35 @@ async function walkJsonFiles(rootDir) {
   }
 
   return files.sort((left, right) => left.localeCompare(right));
+}
+
+async function cleanAuthoredDraftFiles(rootDir) {
+  if (!existsSync(rootDir)) {
+    return;
+  }
+
+  const entries = await readdir(rootDir, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const fullPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      if (LOCAL_DRAFT_CONTEXT_FOLDERS.has(entry.name)) {
+        continue;
+      }
+
+      await cleanAuthoredDraftFiles(fullPath);
+
+      const remainingEntries = await readdir(fullPath, { withFileTypes: true });
+      if (remainingEntries.length === 0) {
+        await rm(fullPath, { recursive: true, force: true });
+      }
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith('.json')) {
+      await rm(fullPath, { force: true });
+    }
+  }
 }
 
 function inferKind(domain, relativePath) {
@@ -133,7 +166,7 @@ async function unpackDraftPackage(draftPackage, draftsRoot, { cleanDomain = fals
 
   const domainRoot = path.resolve(draftsRoot, domain);
   if (cleanDomain && existsSync(domainRoot)) {
-    await rm(domainRoot, { recursive: true, force: true });
+    await cleanAuthoredDraftFiles(domainRoot);
   }
 
   for (const entry of draftPackage.files) {
@@ -203,11 +236,11 @@ async function main() {
       [
         'Usage: node tools/config-draft-sync.mjs <command> [--key=value]',
         'Commands:',
-        '  pack    --domain=example.com [--drafts-root=public/assets/drafts] [--stage=draft] [--output=package.json]',
-        '  unpack  --input=package.json [--drafts-root=public/assets/drafts] [--clean-domain=true]',
-        '  pull    --endpoint=https://... --domain=example.com [--stage=draft] [--drafts-root=public/assets/drafts] [--clean-domain=true]',
-        '  push    --endpoint=https://... --domain=example.com [--drafts-root=public/assets/drafts] [--updated-by=name]',
-        '  create  --endpoint=https://... --domain=example.com [--drafts-root=public/assets/drafts] [--publish-on-create=true]',
+        '  pack    --domain=example.com [--drafts-root=drafts] [--stage=draft] [--output=package.json]',
+        '  unpack  --input=package.json [--drafts-root=drafts] [--clean-domain=true]',
+        '  pull    --endpoint=https://... --domain=example.com [--stage=draft] [--drafts-root=drafts] [--clean-domain=true]',
+        '  push    --endpoint=https://... --domain=example.com [--drafts-root=drafts] [--updated-by=name]',
+        '  create  --endpoint=https://... --domain=example.com [--drafts-root=drafts] [--publish-on-create=true]',
         '  publish --endpoint=https://... --domain=example.com [--version-id=...]',
       ].join('\n') + '\n'
     );

--- a/tools/draft-smoke-check.mjs
+++ b/tools/draft-smoke-check.mjs
@@ -1,0 +1,598 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { chromium } from 'playwright-core';
+
+const DEFAULT_DRAFTS_ROOT = path.resolve('drafts');
+const DEFAULT_LOCAL_BASE_URL = 'http://127.0.0.1:4200';
+const DEFAULT_LIVE_SCHEME = 'https';
+const DEFAULT_BROWSER_TIMEOUT_MS = 20000;
+const MANAGED_ALIAS_SUFFIX = '.zoolandingpage.com.mx';
+const DEBUG_DRAFT_DIRECTORY = '_debug';
+
+const DEFAULT_VIEWPORTS = Object.freeze([
+  Object.freeze({ id: 'desktop', width: 1440, height: 900 }),
+  Object.freeze({ id: 'mobile', width: 390, height: 844 }),
+]);
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+
+  for (const arg of rawArgs) {
+    if (!arg.startsWith('--')) continue;
+
+    const [rawKey, ...valueParts] = arg.slice(2).split('=');
+    const key = rawKey.trim();
+    const value = valueParts.length > 0 ? valueParts.join('=').trim() : 'true';
+    const previous = parsed[key];
+
+    if (previous === undefined) {
+      parsed[key] = value;
+      continue;
+    }
+
+    parsed[key] = Array.isArray(previous) ? previous.concat(value) : [previous, value];
+  }
+
+  return parsed;
+}
+
+function toArray(value) {
+  if (value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function getBooleanArg(args, key, fallback = false) {
+  const fallbackValue = fallback ? 'true' : 'false';
+  const raw = String(args[key] ?? fallbackValue)
+    .trim()
+    .toLowerCase();
+  return ['1', 'true', 'yes', 'on'].includes(raw);
+}
+
+function getIntegerArg(args, key, fallback) {
+  const raw = Number.parseInt(String(args[key] ?? fallback), 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : fallback;
+}
+
+function normalizeRoutePath(routePath) {
+  const raw = String(routePath ?? '').trim();
+  if (!raw || raw === '/') {
+    return '/';
+  }
+
+  return raw.startsWith('/') ? raw : `/${raw}`;
+}
+
+function dedupeRoutes(routes) {
+  const seen = new Set();
+  return routes.filter(route => {
+    const key = `${route.path}::${route.pageId}`;
+    if (seen.has(key)) {
+      return false;
+    }
+
+    seen.add(key);
+    return true;
+  });
+}
+
+function normalizeViewportDefinitions(viewports) {
+  const source = Array.isArray(viewports) && viewports.length > 0 ? viewports : DEFAULT_VIEWPORTS;
+  const seen = new Set();
+
+  return source.map((viewport, index) => {
+    const id = String(viewport?.id ?? `viewport-${index + 1}`).trim();
+    const width = Number.parseInt(String(viewport?.width ?? ''), 10);
+    const height = Number.parseInt(String(viewport?.height ?? ''), 10);
+
+    if (!id) {
+      throw new Error('Each viewport definition requires a non-empty id.');
+    }
+
+    if (seen.has(id)) {
+      throw new Error(`Duplicate viewport id: ${id}`);
+    }
+
+    if (!Number.isFinite(width) || width <= 0 || !Number.isFinite(height) || height <= 0) {
+      throw new Error(`Viewport '${id}' requires positive width and height values.`);
+    }
+
+    seen.add(id);
+    return { id, width, height };
+  });
+}
+
+function createViewportCounts(viewports) {
+  return Object.fromEntries(viewports.map(viewport => [viewport.id, 0]));
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await readFile(filePath, 'utf8'));
+}
+
+async function loadDraftDefinitions(draftsRoot, requestedDomains) {
+  const entries = await readdir(draftsRoot, { withFileTypes: true });
+  const domainsFilter = new Set(requestedDomains);
+  const definitions = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name === DEBUG_DRAFT_DIRECTORY) continue;
+    if (domainsFilter.size > 0 && !domainsFilter.has(entry.name)) continue;
+
+    const siteConfigPath = path.join(draftsRoot, entry.name, 'site-config.json');
+    if (!existsSync(siteConfigPath)) continue;
+
+    const siteConfig = await readJson(siteConfigPath);
+    const routes =
+      Array.isArray(siteConfig.routes) && siteConfig.routes.length > 0
+        ? siteConfig.routes.map(route => ({
+            path: normalizeRoutePath(route?.path),
+            pageId: String(route?.pageId ?? siteConfig.defaultPageId ?? 'default').trim() || 'default',
+          }))
+        : [
+            {
+              path: '/',
+              pageId: String(siteConfig.defaultPageId ?? 'default').trim() || 'default',
+            },
+          ];
+
+    definitions.push({
+      domain: entry.name,
+      defaultPageId: String(siteConfig.defaultPageId ?? 'default').trim() || 'default',
+      managedAlias: Array.isArray(siteConfig.aliases)
+        ? siteConfig.aliases.find(alias => String(alias).trim().toLowerCase().endsWith(MANAGED_ALIAS_SUFFIX)) ?? null
+        : null,
+      routes: dedupeRoutes(routes),
+    });
+  }
+
+  if (definitions.length === 0 && requestedDomains.length > 0) {
+    throw new Error(`No draft folders matched: ${requestedDomains.join(', ')}`);
+  }
+
+  return definitions.sort((left, right) => left.domain.localeCompare(right.domain));
+}
+
+function buildLocalUrl(localBaseUrl, domain, routePath) {
+  const url = new URL(normalizeRoutePath(routePath), localBaseUrl);
+  url.searchParams.set('draftDomain', domain);
+  return url.toString();
+}
+
+function buildLiveUrl(alias, routePath, liveScheme) {
+  return new URL(normalizeRoutePath(routePath), `${liveScheme}://${alias}`).toString();
+}
+
+async function canExecute(command) {
+  return new Promise(resolve => {
+    const child = spawn(command, ['--version'], { stdio: 'ignore', windowsHide: true });
+    child.on('error', () => resolve(false));
+    child.on('exit', code => resolve(code === 0));
+  });
+}
+
+async function resolveBrowserCommand(explicitBrowserPath) {
+  const candidates = [
+    explicitBrowserPath,
+    process.env.DRAFT_SMOKE_BROWSER_PATH,
+    process.env.BROWSER_PATH,
+    process.platform === 'win32' ? 'C:\\Program Files\\Microsoft\\Edge\\Application\\msedge.exe' : null,
+    process.platform === 'win32' ? 'C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe' : null,
+    process.platform === 'win32' ? 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe' : null,
+    process.platform === 'win32' ? 'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe' : null,
+    process.platform === 'darwin' ? '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' : null,
+    process.platform === 'darwin' ? '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge' : null,
+    process.platform === 'linux' ? '/usr/bin/google-chrome' : null,
+    process.platform === 'linux' ? '/usr/bin/microsoft-edge' : null,
+    process.platform === 'linux' ? '/usr/bin/chromium-browser' : null,
+    'msedge',
+    'chrome',
+    'google-chrome',
+    'chromium',
+    'chromium-browser',
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (candidate.includes(path.sep) && !existsSync(candidate)) {
+      continue;
+    }
+
+    if (await canExecute(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error('Unable to locate a supported Chromium-based browser. Pass --browser-path=... if needed.');
+}
+
+async function inspectPage(context, targetUrl, timeoutMs) {
+  const page = await context.newPage();
+
+  try {
+    await page.goto(targetUrl, { waitUntil: 'domcontentloaded', timeout: timeoutMs });
+    await page.waitForFunction(
+      () => {
+        const title = document.title?.trim() || '';
+        const bodyText = document.body?.innerText || '';
+        return (
+          Boolean(title) &&
+          (Boolean(document.querySelector('main h1, main h2, main h3')) || /Unresolved draft/i.test(bodyText))
+        );
+      },
+      { timeout: timeoutMs }
+    );
+    await page.waitForTimeout(500);
+
+    return await page.evaluate(() => {
+      const bodyText = (document.body?.innerText || '').replace(/\s+/g, ' ').trim();
+      const mainHeading = document.querySelector('main h1, main h2, main h3');
+      const hasSearchButton = Boolean(
+        Array.from(document.querySelectorAll('button, [role="button"], a')).find(element => {
+          const text = element.textContent || '';
+          const ariaLabel = element.getAttribute('aria-label') || '';
+          return /búsqueda del sitio|search/i.test(text) || /búsqueda del sitio|search/i.test(ariaLabel);
+        })
+      );
+      const hasHamburgerButton = Boolean(
+        Array.from(document.querySelectorAll('button')).find(element => {
+          const text = element.textContent || '';
+          const ariaLabel = element.getAttribute('aria-label') || '';
+          return /Abrir navegación principal/i.test(text) || /Abrir navegación principal/i.test(ariaLabel);
+        })
+      );
+
+      return {
+        title: document.title?.trim() || '',
+        firstHeading:
+          mainHeading?.textContent?.trim() || document.querySelector('h1, h2, h3')?.textContent?.trim() || '',
+        hasSearchButton,
+        hasHamburgerButton,
+        unresolvedDraft: /Unresolved draft/i.test(bodyText),
+        bodySnippet: bodyText.slice(0, 220),
+      };
+    });
+  } finally {
+    await page.close();
+  }
+}
+
+async function inspectPageWithRetries(context, targetUrl, timeoutMs, attempts = 3) {
+  let lastError = null;
+
+  for (let index = 0; index < attempts; index += 1) {
+    try {
+      return await inspectPage(context, targetUrl, timeoutMs);
+    } catch (error) {
+      lastError = error;
+      if (index === attempts - 1) {
+        break;
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+function compareSummaries(localSummary, liveSummary) {
+  const mismatches = [];
+
+  if (localSummary.title !== liveSummary.title) {
+    mismatches.push(`title: local='${localSummary.title}' live='${liveSummary.title}'`);
+  }
+
+  if (localSummary.firstHeading !== liveSummary.firstHeading) {
+    mismatches.push(`firstHeading: local='${localSummary.firstHeading}' live='${liveSummary.firstHeading}'`);
+  }
+
+  if (localSummary.hasSearchButton !== liveSummary.hasSearchButton) {
+    mismatches.push(`hasSearchButton: local=${localSummary.hasSearchButton} live=${liveSummary.hasSearchButton}`);
+  }
+
+  if (localSummary.hasHamburgerButton !== liveSummary.hasHamburgerButton) {
+    mismatches.push(
+      `hasHamburgerButton: local=${localSummary.hasHamburgerButton} live=${liveSummary.hasHamburgerButton}`
+    );
+  }
+
+  return mismatches;
+}
+
+function validateLocalSummary(summary) {
+  const problems = [];
+
+  if (!summary.title) problems.push('missing title');
+  if (!summary.firstHeading) problems.push('missing first heading');
+  if (summary.unresolvedDraft) problems.push('page rendered unresolved draft fallback');
+
+  return problems;
+}
+
+async function writeOutput(outputPath, payload) {
+  if (!outputPath) {
+    return;
+  }
+
+  const resolved = path.resolve(outputPath);
+  await mkdir(path.dirname(resolved), { recursive: true });
+  await writeFile(resolved, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+function printRouteStatus({ prefix, viewportId, domain, routePath, details }) {
+  process.stdout.write(`${prefix}[${viewportId}] ${domain} ${routePath} ${details}\n`);
+}
+
+async function buildSmokeReport({
+  definitions,
+  inspectPageSummary,
+  viewports = DEFAULT_VIEWPORTS,
+  localBaseUrl,
+  includeLive = true,
+  liveScheme = DEFAULT_LIVE_SCHEME,
+  primaryViewport,
+  timeoutMs = DEFAULT_BROWSER_TIMEOUT_MS,
+  onStatus,
+}) {
+  if (typeof inspectPageSummary !== 'function') {
+    throw new Error('buildSmokeReport requires an inspectPageSummary callback.');
+  }
+
+  const normalizedViewports = normalizeViewportDefinitions(viewports);
+  const requestedPrimaryViewport = String(primaryViewport ?? normalizedViewports[0]?.id ?? '').trim();
+  const primaryViewportId = normalizedViewports.some(viewport => viewport.id === requestedPrimaryViewport)
+    ? requestedPrimaryViewport
+    : normalizedViewports[0]?.id || null;
+  const localFailuresByViewport = createViewportCounts(normalizedViewports);
+  const liveFailuresByViewport = createViewportCounts(normalizedViewports);
+  const skippedLiveRoutesByViewport = createViewportCounts(normalizedViewports);
+  const report = {
+    generatedAt: new Date().toISOString(),
+    localBaseUrl,
+    includeLive,
+    liveScheme,
+    primaryViewport: primaryViewportId,
+    viewports: normalizedViewports.map(viewport => ({ ...viewport })),
+    results: [],
+  };
+
+  let localFailures = 0;
+  let liveFailures = 0;
+  let skippedLiveRoutes = 0;
+
+  for (const definition of definitions) {
+    const draftResult = {
+      domain: definition.domain,
+      managedAlias: definition.managedAlias,
+      routes: [],
+    };
+
+    for (const route of definition.routes) {
+      const localUrl = buildLocalUrl(localBaseUrl, definition.domain, route.path);
+      const liveUrl =
+        includeLive && definition.managedAlias ? buildLiveUrl(definition.managedAlias, route.path, liveScheme) : null;
+      const viewportResults = {};
+
+      for (const viewport of normalizedViewports) {
+        const localSummary = await inspectPageSummary({
+          definition,
+          route,
+          surface: 'local',
+          targetUrl: localUrl,
+          timeoutMs,
+          viewport,
+          viewportId: viewport.id,
+          attempts: 2,
+        });
+        const localProblems = validateLocalSummary(localSummary);
+
+        if (localProblems.length > 0) {
+          localFailures += 1;
+          localFailuresByViewport[viewport.id] += 1;
+          onStatus?.({
+            prefix: '[local fail]',
+            viewportId: viewport.id,
+            domain: definition.domain,
+            routePath: route.path,
+            details: localProblems.join('; '),
+          });
+        } else {
+          onStatus?.({
+            prefix: '[local ok]',
+            viewportId: viewport.id,
+            domain: definition.domain,
+            routePath: route.path,
+            details: `${localSummary.title} | ${localSummary.firstHeading}`,
+          });
+        }
+
+        let liveSummary = null;
+        let liveMismatches = [];
+
+        if (liveUrl) {
+          liveSummary = await inspectPageSummary({
+            definition,
+            route,
+            surface: 'live',
+            targetUrl: liveUrl,
+            timeoutMs,
+            viewport,
+            viewportId: viewport.id,
+            attempts: 3,
+          });
+          liveMismatches = compareSummaries(localSummary, liveSummary);
+
+          if (liveMismatches.length > 0) {
+            liveFailures += 1;
+            liveFailuresByViewport[viewport.id] += 1;
+            onStatus?.({
+              prefix: '[live drift]',
+              viewportId: viewport.id,
+              domain: definition.domain,
+              routePath: route.path,
+              details: liveMismatches.join('; '),
+            });
+          } else {
+            onStatus?.({
+              prefix: '[live ok]',
+              viewportId: viewport.id,
+              domain: definition.domain,
+              routePath: route.path,
+              details: `${definition.managedAlias}`,
+            });
+          }
+        } else if (includeLive) {
+          skippedLiveRoutesByViewport[viewport.id] += 1;
+          onStatus?.({
+            prefix: '[live skip]',
+            viewportId: viewport.id,
+            domain: definition.domain,
+            routePath: route.path,
+            details: 'no managed .zoolandingpage.com.mx alias',
+          });
+        }
+
+        viewportResults[viewport.id] = {
+          viewport: { ...viewport },
+          local: localSummary,
+          localProblems,
+          live: liveSummary,
+          liveMismatches,
+        };
+      }
+
+      if (includeLive && !liveUrl) {
+        skippedLiveRoutes += 1;
+      }
+
+      const primaryResult = viewportResults[primaryViewportId] ?? Object.values(viewportResults)[0] ?? null;
+      draftResult.routes.push({
+        path: route.path,
+        pageId: route.pageId,
+        localUrl,
+        liveUrl,
+        primaryViewport: primaryViewportId,
+        viewports: viewportResults,
+        local: primaryResult?.local ?? null,
+        localProblems: primaryResult?.localProblems ?? [],
+        live: primaryResult?.live ?? null,
+        liveMismatches: primaryResult?.liveMismatches ?? [],
+      });
+    }
+
+    report.results.push(draftResult);
+  }
+
+  report.summary = {
+    draftCount: report.results.length,
+    routeCount: report.results.reduce((total, draft) => total + draft.routes.length, 0),
+    viewportCount: normalizedViewports.length,
+    localFailures,
+    liveFailures,
+    skippedLiveRoutes,
+    localFailuresByViewport,
+    liveFailuresByViewport,
+    skippedLiveRoutesByViewport,
+  };
+
+  return report;
+}
+
+async function createBrowserInspector(browser, viewports) {
+  const contexts = new Map();
+
+  for (const viewport of viewports) {
+    const context = await browser.newContext({
+      viewport: { width: viewport.width, height: viewport.height },
+      ignoreHTTPSErrors: true,
+    });
+    contexts.set(viewport.id, context);
+  }
+
+  return {
+    async inspectPageSummary({ viewportId, targetUrl, timeoutMs, attempts }) {
+      const context = contexts.get(viewportId);
+      if (!context) {
+        throw new Error(`Unknown viewport id: ${viewportId}`);
+      }
+
+      return inspectPageWithRetries(context, targetUrl, timeoutMs, attempts);
+    },
+    async close() {
+      for (const context of contexts.values()) {
+        await context.close();
+      }
+    },
+  };
+}
+
+async function runFromCli(rawArgs = process.argv.slice(2)) {
+  const args = parseArgs(rawArgs);
+  const requestedDomains = toArray(args.domain)
+    .map(value => String(value).trim())
+    .filter(Boolean);
+  const draftsRoot = path.resolve(String(args['drafts-root'] ?? DEFAULT_DRAFTS_ROOT));
+  const localBaseUrl = String(args['local-base-url'] ?? DEFAULT_LOCAL_BASE_URL).trim();
+  const liveScheme = String(args['live-scheme'] ?? DEFAULT_LIVE_SCHEME).trim() || DEFAULT_LIVE_SCHEME;
+  const includeLive = getBooleanArg(args, 'include-live', true);
+  const timeoutMs = getIntegerArg(args, 'timeout-ms', DEFAULT_BROWSER_TIMEOUT_MS);
+  const viewports = normalizeViewportDefinitions(DEFAULT_VIEWPORTS);
+  const browserCommand = await resolveBrowserCommand(String(args['browser-path'] ?? '').trim() || null);
+  const definitions = await loadDraftDefinitions(draftsRoot, requestedDomains);
+  const browser = await chromium.launch({ executablePath: browserCommand, headless: true });
+  const inspector = await createBrowserInspector(browser, viewports);
+
+  try {
+    const report = await buildSmokeReport({
+      definitions,
+      inspectPageSummary: inspector.inspectPageSummary,
+      viewports,
+      localBaseUrl,
+      includeLive,
+      liveScheme,
+      timeoutMs,
+      onStatus: printRouteStatus,
+    });
+
+    report.browserCommand = browserCommand;
+    report.draftsRoot = draftsRoot;
+
+    await writeOutput(String(args.output ?? '').trim(), report);
+
+    process.stdout.write(
+      `\nSummary: ${report.summary.routeCount} routes across ${report.summary.draftCount} drafts and ${report.summary.viewportCount} viewports. Local failures: ${report.summary.localFailures}. Live mismatches: ${report.summary.liveFailures}. Skipped live routes: ${report.summary.skippedLiveRoutes}.\n`
+    );
+
+    if (report.summary.localFailures > 0 || report.summary.liveFailures > 0) {
+      process.exitCode = 1;
+    }
+
+    return report;
+  } finally {
+    await inspector.close();
+    await browser.close();
+  }
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : '';
+
+if (invokedPath && import.meta.url === invokedPath) {
+  runFromCli().catch(error => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}
+
+export {
+  DEFAULT_VIEWPORTS,
+  buildSmokeReport,
+  compareSummaries,
+  inspectPageWithRetries,
+  loadDraftDefinitions,
+  normalizeViewportDefinitions,
+  runFromCli,
+  validateLocalSummary,
+};

--- a/tools/draft-smoke-check.mjs
+++ b/tools/draft-smoke-check.mjs
@@ -221,7 +221,7 @@ async function inspectPage(context, targetUrl, timeoutMs) {
         const bodyText = document.body?.innerText || '';
         return (
           Boolean(title) &&
-          (Boolean(document.querySelector('main h1, main h2, main h3')) || /Unresolved draft/i.test(bodyText))
+          (Boolean(document.querySelector('h1, h2, h3')) || /Unresolved draft/i.test(bodyText))
         );
       },
       { timeout: timeoutMs }

--- a/tools/tests/draft-local-context.spec.mjs
+++ b/tools/tests/draft-local-context.spec.mjs
@@ -1,0 +1,245 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import net from 'node:net';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(fileURLToPath(new URL('../..', import.meta.url)));
+const draftSyncCliPath = path.join(repoRoot, 'tools', 'config-draft-sync.mjs');
+const builtServerPath = path.join(repoRoot, 'dist', 'zoolandingpage', 'server', 'server.mjs');
+
+async function writeJson(filePath, value) {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd ?? repoRoot,
+      env: { ...process.env, ...(options.env ?? {}) },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', chunk => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on('data', chunk => {
+      stderr += chunk.toString();
+    });
+
+    child.on('error', reject);
+    child.on('exit', code => {
+      if (code === 0) {
+        resolve({ stdout, stderr });
+        return;
+      }
+
+      reject(new Error(`Command failed with exit code ${code}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`));
+    });
+  });
+}
+
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('Failed to determine a free port.')));
+        return;
+      }
+
+      const { port } = address;
+      server.close(error => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(port);
+      });
+    });
+    server.on('error', reject);
+  });
+}
+
+async function waitForServer(url, timeoutMs = 15000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) {
+        return;
+      }
+    } catch {
+      // Keep polling until the timeout expires.
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 200));
+  }
+
+  throw new Error(`Timed out waiting for server readiness at ${url}`);
+}
+
+async function stopServer(child) {
+  if (child.killed || child.exitCode !== null || child.signalCode !== null) {
+    return;
+  }
+
+  child.kill();
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Timed out waiting for the draft test server to stop.'));
+    }, 5000);
+
+    child.once('exit', () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+}
+
+test('config-draft-sync excludes local-only folders and preserves them during clean unpack', async t => {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'zoolanding-draft-sync-'));
+  t.after(async () => {
+    await rm(tempRoot, { recursive: true, force: true });
+  });
+
+  const draftsRoot = path.join(tempRoot, 'drafts');
+  const domainRoot = path.join(draftsRoot, 'fixture.example.com');
+  const packagePath = path.join(tempRoot, 'fixture-package.json');
+
+  await writeJson(path.join(domainRoot, 'site-config.json'), {
+    version: 1,
+    domain: 'fixture.example.com',
+    defaultPageId: 'default',
+    routes: [{ path: '/', pageId: 'default' }],
+  });
+  await writeJson(path.join(domainRoot, 'default', 'page-config.json'), {
+    version: 1,
+    domain: 'fixture.example.com',
+    pageId: 'default',
+    rootIds: ['hero'],
+    modalRootIds: [],
+  });
+  await writeJson(path.join(domainRoot, 'ai_notes', 'keep.json'), { keep: 'ai-notes' });
+  await writeJson(path.join(domainRoot, 'findings', 'keep.json'), { keep: 'findings' });
+  await writeJson(path.join(domainRoot, 'errors-reports', 'keep.json'), { keep: 'errors-reports' });
+
+  await runCommand(process.execPath, [
+    draftSyncCliPath,
+    'pack',
+    '--domain=fixture.example.com',
+    `--drafts-root=${draftsRoot}`,
+    `--output=${packagePath}`,
+  ]);
+
+  const packaged = JSON.parse(await readFile(packagePath, 'utf8'));
+  const packagedPaths = packaged.files.map(entry => entry.path).sort();
+
+  assert.deepEqual(packagedPaths, [
+    'fixture.example.com/default/page-config.json',
+    'fixture.example.com/site-config.json',
+  ]);
+
+  await writeJson(path.join(domainRoot, 'default', 'stale.json'), { stale: true });
+
+  await runCommand(process.execPath, [
+    draftSyncCliPath,
+    'unpack',
+    `--input=${packagePath}`,
+    `--drafts-root=${draftsRoot}`,
+    '--clean-domain=true',
+  ]);
+
+  assert.equal(existsSync(path.join(domainRoot, 'default', 'page-config.json')), true);
+  assert.equal(existsSync(path.join(domainRoot, 'default', 'stale.json')), false);
+  assert.equal(existsSync(path.join(domainRoot, 'ai_notes', 'keep.json')), true);
+  assert.equal(existsSync(path.join(domainRoot, 'findings', 'keep.json')), true);
+  assert.equal(existsSync(path.join(domainRoot, 'errors-reports', 'keep.json')), true);
+});
+
+test('built SSR server hides local-only draft folders from registry and static serving', async t => {
+  assert.equal(
+    existsSync(builtServerPath),
+    true,
+    'Built SSR server not found. Run this test through `npm run test:draft-context` or build first.'
+  );
+
+  const workspaceRoot = await mkdtemp(path.join(tmpdir(), 'zoolanding-server-'));
+
+  const domainRoot = path.join(workspaceRoot, 'drafts', 'fixture.example.com');
+  await writeJson(path.join(domainRoot, 'site-config.json'), {
+    version: 1,
+    domain: 'fixture.example.com',
+    defaultPageId: 'default',
+    routes: [{ path: '/', pageId: 'default' }],
+  });
+  await writeJson(path.join(domainRoot, 'default', 'page-config.json'), {
+    version: 1,
+    domain: 'fixture.example.com',
+    pageId: 'default',
+    rootIds: ['hero'],
+    modalRootIds: [],
+  });
+  await writeJson(path.join(domainRoot, 'ai_notes', 'note.json'), { hidden: true });
+  await writeJson(path.join(domainRoot, 'findings', 'note.json'), { hidden: true });
+  await writeJson(path.join(domainRoot, 'errors-reports', 'note.json'), { hidden: true });
+
+  const port = await getFreePort();
+  const child = spawn(process.execPath, [builtServerPath], {
+    cwd: workspaceRoot,
+    env: {
+      ...process.env,
+      PORT: String(port),
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+
+  let serverOutput = '';
+  child.stdout.on('data', chunk => {
+    serverOutput += chunk.toString();
+  });
+  child.stderr.on('data', chunk => {
+    serverOutput += chunk.toString();
+  });
+
+  t.after(async () => {
+    await stopServer(child);
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  await waitForServer(`http://127.0.0.1:${port}/api/debug/drafts`);
+
+  const registryResponse = await fetch(`http://127.0.0.1:${port}/api/debug/drafts`);
+  assert.equal(registryResponse.ok, true, serverOutput);
+  const registryPayload = await registryResponse.json();
+  assert.deepEqual(registryPayload.drafts, [{ domain: 'fixture.example.com', pageId: 'default' }]);
+
+  const pageConfigResponse = await fetch(
+    `http://127.0.0.1:${port}/drafts/fixture.example.com/default/page-config.json`
+  );
+  assert.equal(pageConfigResponse.status, 200, serverOutput);
+
+  const aiNotesResponse = await fetch(`http://127.0.0.1:${port}/drafts/fixture.example.com/ai_notes/note.json`);
+  assert.equal(aiNotesResponse.status, 404, serverOutput);
+
+  const findingsResponse = await fetch(`http://127.0.0.1:${port}/drafts/fixture.example.com/findings/note.json`);
+  assert.equal(findingsResponse.status, 404, serverOutput);
+
+  const errorsReportsResponse = await fetch(
+    `http://127.0.0.1:${port}/drafts/fixture.example.com/errors-reports/note.json`
+  );
+  assert.equal(errorsReportsResponse.status, 404, serverOutput);
+});

--- a/tools/tests/draft-smoke-check.spec.mjs
+++ b/tools/tests/draft-smoke-check.spec.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { DEFAULT_VIEWPORTS, buildSmokeReport } from '../draft-smoke-check.mjs';
+
+function createSummary(label) {
+  return {
+    title: `${label} title`,
+    firstHeading: `${label} heading`,
+    hasSearchButton: label.includes('desktop'),
+    hasHamburgerButton: label.includes('mobile'),
+    unresolvedDraft: false,
+    bodySnippet: `${label} snippet`,
+  };
+}
+
+test('buildSmokeReport records desktop and mobile results per route', async () => {
+  const calls = [];
+  const report = await buildSmokeReport({
+    definitions: [
+      {
+        domain: 'example.com',
+        managedAlias: 'example.zoolandingpage.com.mx',
+        routes: [{ path: '/', pageId: 'default' }],
+      },
+    ],
+    viewports: DEFAULT_VIEWPORTS,
+    localBaseUrl: 'http://127.0.0.1:4200',
+    includeLive: true,
+    liveScheme: 'https',
+    inspectPageSummary: async ({ viewportId, surface, targetUrl }) => {
+      calls.push({ viewportId, surface, targetUrl });
+      return createSummary(viewportId);
+    },
+  });
+
+  assert.equal(calls.length, 4);
+
+  const route = report.results[0]?.routes[0];
+  assert.deepEqual(Object.keys(route.viewports), ['desktop', 'mobile']);
+  assert.equal(route.viewports.desktop.local.title, 'desktop title');
+  assert.equal(route.viewports.mobile.local.title, 'mobile title');
+  assert.equal(route.viewports.desktop.live.title, 'desktop title');
+  assert.equal(route.viewports.mobile.live.title, 'mobile title');
+  assert.equal(route.primaryViewport, 'desktop');
+  assert.equal(route.local.title, 'desktop title');
+  assert.equal(route.live.title, 'desktop title');
+  assert.equal(report.summary.routeCount, 1);
+  assert.equal(report.summary.localFailures, 0);
+  assert.equal(report.summary.liveFailures, 0);
+  assert.deepEqual(report.summary.localFailuresByViewport, { desktop: 0, mobile: 0 });
+  assert.deepEqual(report.summary.liveFailuresByViewport, { desktop: 0, mobile: 0 });
+});
+
+test('buildSmokeReport tracks skipped live checks once per route and per viewport', async () => {
+  const report = await buildSmokeReport({
+    definitions: [
+      {
+        domain: 'local-only.example.com',
+        managedAlias: null,
+        routes: [{ path: '/contact', pageId: 'contact' }],
+      },
+    ],
+    viewports: DEFAULT_VIEWPORTS,
+    localBaseUrl: 'http://127.0.0.1:4200',
+    includeLive: true,
+    liveScheme: 'https',
+    inspectPageSummary: async ({ viewportId, surface }) => createSummary(`${surface}-${viewportId}`),
+  });
+
+  const route = report.results[0]?.routes[0];
+  assert.equal(route.liveUrl, null);
+  assert.equal(route.viewports.desktop.live, null);
+  assert.equal(route.viewports.mobile.live, null);
+  assert.equal(report.summary.skippedLiveRoutes, 1);
+  assert.deepEqual(report.summary.skippedLiveRoutesByViewport, { desktop: 1, mobile: 1 });
+});

--- a/zoolandingpage.code-workspace
+++ b/zoolandingpage.code-workspace
@@ -26,6 +26,7 @@
     "typescript.suggest.includeCompletionsForImportStatements": true,
     "typescript.suggest.includeCompletionsForModuleExports": true,
     "angular.experimental-ivy": true,
+    "chat.promptFilesRecommendations": true,
 
     // Configuración de archivos
     "files.associations": {


### PR DESCRIPTION
Introduce canonical ai-notes, Codex, AGENTS.md and several .github agent/prompt/skill docs to formalize repo workflow and release-readiness rules. Move local draft source to a top-level drafts/ tree (update .gitignore and README accordingly) and add repo-level guidelines for draft-specific notes. Add a draft smoke-check tool and tests (tools/draft-smoke-check.mjs + tests), update tooling (package.json) and workspace, and make assorted updates to Angular runtime/config services, tests, and docs to align with the new draft/workflow conventions.