### PR TITLE
Block HTML host, canonical og:url, sitemap dedupe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ Thumbs.db
 /drafts/*
 !/drafts/.gitignore
 /devonly/
+/reports/

--- a/ai-notes/constraints/ssr-hydration-and-canonical-sitemap.md
+++ b/ai-notes/constraints/ssr-hydration-and-canonical-sitemap.md
@@ -1,0 +1,33 @@
+Date: 2026-04-28 (Central Time)
+Scope: Reusable SSR hydration and canonical-SEO constraints for shared landing runtime behavior.
+Status: Active
+Applies To: Shared authored HTML rendering, SEO fallback metadata, sitemap generation
+Source Of Truth:
+
+- src/app/shared/components/generic-text/generic-text.ts
+- src/app/shared/services/seo-metadata.service.ts
+- src/server.ts
+- drafts/pamelabetancourt.com/site-config.json
+- drafts/pamelabetancourt.com/home/page-config.json
+  Confidence: High
+  Last Reviewed: 2026-04-28 (Central Time)
+
+# SSR Hydration And Canonical Sitemap Rules
+
+## Rule
+
+- Do not render block-authored HTML inside inline or paragraph hosts in `GenericText`; promote those payloads to a block-safe host first.
+- When a page omits `og:url`, fall back to the canonical page URL instead of the raw document origin.
+- When generating `sitemap.xml`, dedupe routes by resolved canonical page URL, not by raw route path, because one page can intentionally ship multiple public aliases.
+
+## Why It Exists
+
+- Invalid authored HTML nesting can survive SSR output but fail during production hydration with Angular `nextSibling` errors.
+- Proxy, local, or alias origins can differ from the intended canonical `https` URL, which makes raw-origin SEO fallbacks drift from page intent.
+- Multi-route pages such as Pamela can legally expose both `/` and `/home` in routing while only one of them should remain indexable in sitemap output.
+
+## How To Work Safely
+
+1. If shared text payloads can contain block HTML like `<p>`, `<ul>`, or multiple paragraphs, validate them with a production SSR browser pass in desktop and mobile viewports.
+2. For SEO fallback changes, inspect the rendered canonical link, `og:url`, and default OG or Twitter image URLs on both canonical and alias routes.
+3. For sitemap changes, verify the generated XML with real host headers and confirm duplicate page routes collapse to the canonical URL.

--- a/ai-notes/knowledge/platform-operations-and-recovery-lessons.md
+++ b/ai-notes/knowledge/platform-operations-and-recovery-lessons.md
@@ -23,6 +23,12 @@ Keep Systems Manager access available on the active host so recovery does not de
 
 After edge routing is repaired, verify the actual application service state on the active host before declaring the incident closed. A broken container image or missing local image can keep the site down even after the edge layer is healthy again.
 
+## Edge Verification Lesson
+
+If CloudFront-backed domains still look broken after the origin host recovers, confirm the edge-to-origin path before changing host routing again. Traefik access logs can prove whether CloudFront is still reaching the origin over HTTP and receiving `200` responses even when some local CLI clients report TLS or connection-reset errors.
+
+On Windows recovery work, do not trust one failing client alone. `curl.exe` and Node or undici may show `ECONNRESET` while PowerShell `Invoke-WebRequest`, .NET `HttpClient`, and Traefik access logs show the public page is actually serving correctly through CloudFront.
+
 ## SSR Runtime Fallback Lesson
 
 If browser fetches to the stable API custom domain are healthy but Node or undici requests from the SSR container intermittently fail with transport resets, keep the browser-facing base URL on the custom domain and add a server-only fallback for `runtime-bundle` to the raw runtime-read origin base. That isolates the issue to SSR transport without changing public browser URLs or alias resolution behavior.

--- a/src/app/shared/components/generic-text/generic-text.html
+++ b/src/app/shared/components/generic-text/generic-text.html
@@ -1,53 +1,77 @@
-<ng-template #contentTpl>
-  @if (useHtml()) {
-  <span [attr.id]="contentId()" [innerHTML]="safeHtml()"></span>
-  } @else {
+<ng-template #textTpl>
   <span [attr.id]="contentId()" style="display: contents">{{ text() }}</span>
-  }
 </ng-template>
 
-@switch (tag()) { @case ('h1') {
+@switch (tag()) { @case ('h1') { @if (useHtml()) {
+<h1 [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()" [innerHTML]="safeHtml()"></h1>
+} @else {
 <h1 [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()">
-  <ng-container [ngTemplateOutlet]="contentTpl"></ng-container>
+  <ng-container [ngTemplateOutlet]="textTpl"></ng-container>
 </h1>
-} @case ('h2') {
+} } @case ('h2') { @if (useHtml()) {
+<h2 [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()" [innerHTML]="safeHtml()"></h2>
+} @else {
 <h2 [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()">
-  <ng-container [ngTemplateOutlet]="contentTpl"></ng-container>
+  <ng-container [ngTemplateOutlet]="textTpl"></ng-container>
 </h2>
-} @case ('h3') {
+} } @case ('h3') { @if (useHtml()) {
+<h3 [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()" [innerHTML]="safeHtml()"></h3>
+} @else {
 <h3 [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()">
-  <ng-container [ngTemplateOutlet]="contentTpl"></ng-container>
+  <ng-container [ngTemplateOutlet]="textTpl"></ng-container>
 </h3>
-} @case ('h4') {
+} } @case ('h4') { @if (useHtml()) {
+<h4 [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()" [innerHTML]="safeHtml()"></h4>
+} @else {
 <h4 [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()">
-  <ng-container [ngTemplateOutlet]="contentTpl"></ng-container>
+  <ng-container [ngTemplateOutlet]="textTpl"></ng-container>
 </h4>
-} @case ('h5') {
+} } @case ('h5') { @if (useHtml()) {
+<h5 [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()" [innerHTML]="safeHtml()"></h5>
+} @else {
 <h5 [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()">
-  <ng-container [ngTemplateOutlet]="contentTpl"></ng-container>
+  <ng-container [ngTemplateOutlet]="textTpl"></ng-container>
 </h5>
-} @case ('h6') {
+} } @case ('h6') { @if (useHtml()) {
+<h6 [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()" [innerHTML]="safeHtml()"></h6>
+} @else {
 <h6 [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()">
-  <ng-container [ngTemplateOutlet]="contentTpl"></ng-container>
+  <ng-container [ngTemplateOutlet]="textTpl"></ng-container>
 </h6>
-} @case ('span') {
+} } @case ('span') { @if (useHtml()) {
+<span [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()" [innerHTML]="safeHtml()"></span>
+} @else {
 <span [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()"
-  ><ng-container [ngTemplateOutlet]="contentTpl"></ng-container
+  ><ng-container [ngTemplateOutlet]="textTpl"></ng-container
 ></span>
-} @case ('small') {
+} } @case ('small') { @if (useHtml()) {
+<small [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()" [innerHTML]="safeHtml()"></small>
+} @else {
 <small [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()"
-  ><ng-container [ngTemplateOutlet]="contentTpl"></ng-container
+  ><ng-container [ngTemplateOutlet]="textTpl"></ng-container
 ></small>
-} @case ('strong') {
+} } @case ('strong') { @if (useHtml()) {
+<strong [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()" [innerHTML]="safeHtml()"></strong>
+} @else {
 <strong [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()"
-  ><ng-container [ngTemplateOutlet]="contentTpl"></ng-container
+  ><ng-container [ngTemplateOutlet]="textTpl"></ng-container
 ></strong>
-} @case ('em') {
+} } @case ('em') { @if (useHtml()) {
+<em [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()" [innerHTML]="safeHtml()"></em>
+} @else {
 <em [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()"
-  ><ng-container [ngTemplateOutlet]="contentTpl"></ng-container
+  ><ng-container [ngTemplateOutlet]="textTpl"></ng-container
 ></em>
-} @case ('p') {
+} } @case ('p') { @if (useHtml()) {
+<p [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()" [innerHTML]="safeHtml()"></p>
+} @else {
 <p [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()">
-  <ng-container [ngTemplateOutlet]="contentTpl"></ng-container>
+  <ng-container [ngTemplateOutlet]="textTpl"></ng-container>
 </p>
-} @default { <ng-container [ngTemplateOutlet]="contentTpl"></ng-container> } }
+} } @case ('div') {
+<div [id]="id()" [class]="classes()" [attr.aria-label]="ariaLabel()" [innerHTML]="safeHtml()"></div>
+} @default { @if (useHtml()) {
+<span [attr.id]="contentId()" [innerHTML]="safeHtml()"></span>
+} @else {
+<ng-container [ngTemplateOutlet]="textTpl"></ng-container>
+} } }

--- a/src/app/shared/components/generic-text/generic-text.spec.ts
+++ b/src/app/shared/components/generic-text/generic-text.spec.ts
@@ -34,6 +34,21 @@ describe('GenericTextComponent', () => {
     expect(paragraph.innerHTML).not.toContain('<script>');
   });
 
+  it('renders block authored html inside a div host when the configured tag would create invalid markup', () => {
+    fixture.componentRef.setInput('componentId', 'help-list');
+    fixture.componentRef.setInput('config', {
+      html: '<ul><li>One</li><li>Two</li></ul>',
+    });
+
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement.querySelector('#help-list-text') as HTMLDivElement | null;
+
+    expect(host?.tagName).toBe('DIV');
+    expect(host?.querySelectorAll('li').length).toBe(2);
+    expect(fixture.nativeElement.querySelector('p')).toBeNull();
+  });
+
   it('should compose root and content ids from the component id when config.id is missing', () => {
     fixture.componentRef.setInput('componentId', 'intro');
     fixture.componentRef.setInput('config', {

--- a/src/app/shared/components/generic-text/generic-text.ts
+++ b/src/app/shared/components/generic-text/generic-text.ts
@@ -4,6 +4,10 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { composeDomId, resolveComponentDomIdBase, resolveComponentRootDomId, resolveDynamicValue } from '../../utility/component-orchestrator.utility';
 import { GenericTextTag, TGenericTextConfig } from './generic-text.types';
 
+type TRenderedGenericTextTag = GenericTextTag | 'div';
+
+const BLOCK_HTML_PATTERN = /<(address|article|aside|blockquote|details|div|dl|fieldset|figcaption|figure|footer|form|h[1-6]|header|hr|li|main|nav|ol|p|pre|section|summary|table|thead|tbody|tfoot|tr|td|th|ul)\b/i;
+
 @Component({
   selector: 'generic-text',
   imports: [CommonModule],
@@ -19,9 +23,15 @@ export class GenericTextComponent {
   });
   readonly componentId = input<string | undefined>(undefined);
 
-  readonly tag = computed<GenericTextTag>(() => {
+  readonly tag = computed<TRenderedGenericTextTag>(() => {
     const resolved = resolveDynamicValue(this.config().tag);
-    return (resolved as GenericTextTag) ?? 'p';
+    const configuredTag = (resolved as GenericTextTag | null) ?? 'p';
+
+    if (this.useHtml() && this.containsBlockHtml()) {
+      return 'div';
+    }
+
+    return configuredTag;
   });
   readonly text = computed(() => {
     return resolveDynamicValue(this.config().text) ?? '';
@@ -43,4 +53,6 @@ export class GenericTextComponent {
   });
 
   readonly useHtml = computed(() => !!this.safeHtml());
+
+  readonly containsBlockHtml = computed(() => BLOCK_HTML_PATTERN.test(this.safeHtml() ?? ''));
 }

--- a/src/app/shared/services/seo-metadata.service.spec.ts
+++ b/src/app/shared/services/seo-metadata.service.spec.ts
@@ -191,4 +191,61 @@ describe('SeoMetadataService', () => {
             content: 'index,follow,max-snippet:-1,max-image-preview:large',
         });
     });
+
+    it('uses the canonical page url as the fallback og:url when no page openGraph url is provided', () => {
+        TestBed.resetTestingModule();
+
+        title = jasmine.createSpyObj<Title>('Title', ['setTitle']);
+        meta = jasmine.createSpyObj<Meta>('Meta', ['updateTag', 'removeTag']);
+
+        const baseDoc = document.implementation.createHTMLDocument('seo');
+        const seoDoc = {
+            documentElement: baseDoc.documentElement,
+            head: baseDoc.head,
+            createElement: baseDoc.createElement.bind(baseDoc),
+            defaultView: {
+                location: {
+                    origin: 'http://pamelabetancourt.zoolandingpage.com.mx',
+                    pathname: '/',
+                },
+            },
+        } as unknown as Document;
+
+        TestBed.configureTestingModule({
+            providers: [
+                SeoMetadataService,
+                { provide: DOCUMENT, useValue: seoDoc },
+                { provide: Title, useValue: title },
+                { provide: Meta, useValue: meta },
+                {
+                    provide: DomainResolverService,
+                    useValue: {
+                        resolveDomain: () => ({ domain: 'pamelabetancourt.zoolandingpage.com.mx' }),
+                    },
+                },
+                {
+                    provide: RuntimeConfigService,
+                    useValue: {
+                        seoDefaults: () => ({
+                            canonicalOrigin: 'https://pamelabetancourt.zoolandingpage.com.mx',
+                        }),
+                        appName: () => 'Pamela Betancourt',
+                        appDescription: () => 'Pamela site',
+                    },
+                },
+            ],
+        });
+
+        service = TestBed.inject(SeoMetadataService);
+        service.apply('es', {
+            title: 'Pamela Betancourt | Home',
+            description: 'More strategy, less improvisation.',
+            canonical: 'https://pamelabetancourt.zoolandingpage.com.mx/home',
+        } as never);
+
+        expect(meta.updateTag).toHaveBeenCalledWith({
+            property: 'og:url',
+            content: 'https://pamelabetancourt.zoolandingpage.com.mx/home',
+        });
+    });
 });

--- a/src/app/shared/services/seo-metadata.service.ts
+++ b/src/app/shared/services/seo-metadata.service.ts
@@ -40,9 +40,12 @@ export class SeoMetadataService {
             this.syncNamedMetaTag('keywords', seoKeywords);
             this.syncNamedMetaTag('robots', seoRobots);
 
-            const origin = doc.defaultView?.location?.origin || this.cleanString(siteSeo?.canonicalOrigin) || this.defaultOrigin();
-            const pathname = doc.defaultView?.location?.pathname || '/';
-            const url = `${ origin }${ pathname || '/' }`;
+            const origin = this.cleanString(siteSeo?.canonicalOrigin)
+                || this.cleanString(doc.defaultView?.location?.origin)
+                || this.defaultOrigin();
+            const pathname = this.normalizePathname(doc.defaultView?.location?.pathname);
+            const url = `${ origin }${ pathname }`;
+            const canonicalUrl = this.resolveLocalizedText(seo?.canonical, lang) || url;
             const ogLocale = toOpenGraphLocale(lang) || 'en_US';
             const openGraphDefaults = this.resolveLocalizedRecord(this.asRecord(siteSeo?.openGraph), lang);
             const twitterDefaults = this.resolveLocalizedRecord(this.asRecord(siteSeo?.twitter), lang);
@@ -54,6 +57,7 @@ export class SeoMetadataService {
                 ...twitterDefaults,
                 ...this.asRecord(seo?.twitter),
             }, lang);
+            const openGraphUrl = this.cleanString(openGraph['url']) || canonicalUrl;
             const defaultImage = this.cleanString(siteSeo?.defaultImage)
                 || this.cleanString(openGraphDefaults['image'])
                 || this.cleanString(twitterDefaults['image'])
@@ -62,7 +66,7 @@ export class SeoMetadataService {
             this.meta.updateTag({ property: 'og:title', content: String(openGraph['title'] ?? seoTitle) });
             this.meta.updateTag({ property: 'og:description', content: String(openGraph['description'] ?? seoDescription) });
             this.meta.updateTag({ property: 'og:type', content: String(openGraph['type'] ?? 'website') });
-            this.meta.updateTag({ property: 'og:url', content: String(openGraph['url'] ?? url) });
+            this.meta.updateTag({ property: 'og:url', content: openGraphUrl });
             this.meta.updateTag({ property: 'og:image', content: String(openGraph['image'] ?? defaultImage) });
             this.meta.updateTag({ property: 'og:locale', content: String(openGraph['locale'] ?? ogLocale) });
             this.meta.updateTag({ property: 'og:site_name', content: String(openGraph['site_name'] ?? fallbackSiteName) });
@@ -80,7 +84,7 @@ export class SeoMetadataService {
                     linkEl.setAttribute('rel', 'canonical');
                     head.appendChild(linkEl);
                 }
-                linkEl.setAttribute('href', this.resolveLocalizedText(seo?.canonical, lang) || url);
+                linkEl.setAttribute('href', canonicalUrl);
             }
         } catch {
             // no-op for SSR
@@ -196,6 +200,11 @@ export class SeoMetadataService {
 
     private cleanString(value: unknown): string {
         return typeof value === 'string' ? value.trim() : '';
+    }
+
+    private normalizePathname(value: unknown): string {
+        const pathname = this.cleanString(value) || '/';
+        return pathname.startsWith('/') ? pathname : `/${ pathname }`;
     }
 
     private defaultOrigin(): string {

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@ import {
 } from '@angular/ssr/node';
 import express from 'express';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 const browserDistFolder = join(import.meta.dirname, '../browser');
 const DRAFTS_FOLDER_NAME = 'drafts';
@@ -28,6 +28,18 @@ type TDraftRegistryEntry = {
 
 type TSiteConfigRouteEntry = {
   readonly path?: string;
+  readonly pageId?: string;
+};
+
+type TLocalPageConfig = {
+  readonly seo?: {
+    readonly canonical?: string;
+  };
+};
+
+type TRuntimeBundlePayload = {
+  readonly siteConfig?: unknown;
+  readonly pageConfig?: unknown;
 };
 
 type TLocalSiteConfig = {
@@ -155,6 +167,20 @@ function loadLocalSiteConfig(domain: string): TLocalSiteConfig | null {
   return readJsonFile(siteConfigPath) as TLocalSiteConfig | null;
 }
 
+function loadLocalPageConfig(domain: string, pageId: string): TLocalPageConfig | null {
+  const normalizedPageId = String(pageId ?? '').trim();
+  if (!normalizedPageId) {
+    return null;
+  }
+
+  const siteConfigPath = resolveSiteConfigPath(domain);
+  if (!siteConfigPath) {
+    return null;
+  }
+
+  return readJsonFile(join(dirname(siteConfigPath), normalizedPageId, 'page-config.json')) as TLocalPageConfig | null;
+}
+
 async function loadRuntimeSiteConfig(domain: string): Promise<TLocalSiteConfig | null> {
   const normalizedDomain = normalizeHost(domain);
   if (!normalizedDomain || !DEFAULT_CONFIG_API_URL) {
@@ -171,11 +197,44 @@ async function loadRuntimeSiteConfig(domain: string): Promise<TLocalSiteConfig |
       return null;
     }
 
-    const payload = await response.json() as { siteConfig?: unknown };
+    const payload = await response.json() as TRuntimeBundlePayload;
     return isRecord(payload?.siteConfig) ? payload.siteConfig as TLocalSiteConfig : null;
   } catch {
     return null;
   }
+}
+
+async function loadRuntimePageConfig(domain: string, path: string): Promise<TLocalPageConfig | null> {
+  const normalizedDomain = normalizeHost(domain);
+  if (!normalizedDomain || !DEFAULT_CONFIG_API_URL) {
+    return null;
+  }
+
+  try {
+    const url = new URL('/runtime-bundle', `${DEFAULT_CONFIG_API_URL.replace(/\/$/, '')}/`);
+    url.searchParams.set('domain', normalizedDomain);
+    url.searchParams.set('path', normalizeRoutePath(path));
+
+    const response = await fetch(url.toString());
+    if (!response.ok) {
+      return null;
+    }
+
+    const payload = await response.json() as TRuntimeBundlePayload;
+    return isRecord(payload?.pageConfig) ? payload.pageConfig as TLocalPageConfig : null;
+  } catch {
+    return null;
+  }
+}
+
+async function loadPageConfigForRoute(domain: string, route: TSiteConfigRouteEntry): Promise<TLocalPageConfig | null> {
+  const pageId = String(route.pageId ?? '').trim();
+  const localPageConfig = pageId ? loadLocalPageConfig(domain, pageId) : null;
+  if (localPageConfig) {
+    return localPageConfig;
+  }
+
+  return loadRuntimePageConfig(domain, normalizeRoutePath(route.path));
 }
 
 async function loadSiteConfigForHost(domain: string): Promise<TLocalSiteConfig | null> {
@@ -230,12 +289,30 @@ function buildRobotsTxt(req: express.Request, host: string, siteConfig: TLocalSi
   return ['User-agent: *', 'Allow: /', `Sitemap: ${sitemapUrl}`].join('\n');
 }
 
-function buildSitemapXml(req: express.Request, host: string, siteConfig: TLocalSiteConfig | null): string {
+function resolveCanonicalSitemapUrl(origin: string, routePath: string, pageConfig: TLocalPageConfig | null): string {
+  const canonical = String(pageConfig?.seo?.canonical ?? '').trim();
+  if (!canonical) {
+    return new URL(normalizeRoutePath(routePath), origin).toString();
+  }
+
+  try {
+    return new URL(canonical, origin).toString();
+  } catch {
+    return new URL(normalizeRoutePath(routePath), origin).toString();
+  }
+}
+
+async function buildSitemapXml(req: express.Request, host: string, siteConfig: TLocalSiteConfig | null): Promise<string> {
   const origin = `${resolveCanonicalOrigin(req, host, siteConfig).replace(/\/$/, '')}/`;
   const rawRoutes = Array.isArray(siteConfig?.routes) && siteConfig.routes.length > 0
     ? siteConfig.routes
     : [{ path: '/' }];
-  const urls = Array.from(new Set(rawRoutes.map((route) => new URL(normalizeRoutePath(route.path), origin).toString())));
+  const sitemapDomain = normalizeHost(host) || normalizeHost(siteConfig?.domain);
+  const resolvedUrls = await Promise.all(rawRoutes.map(async (route) => {
+    const pageConfig = sitemapDomain ? await loadPageConfigForRoute(sitemapDomain, route) : null;
+    return resolveCanonicalSitemapUrl(origin, normalizeRoutePath(route.path), pageConfig);
+  }));
+  const urls = Array.from(new Set(resolvedUrls));
   const entries = urls
     .map((url) => `  <url>\n    <loc>${escapeXml(url)}</loc>\n  </url>`)
     .join('\n');
@@ -301,7 +378,7 @@ app.get('/robots.txt', async (req, res) => {
 app.get('/sitemap.xml', async (req, res) => {
   const host = resolveRequestHost(req);
   const siteConfig = await loadSiteConfigForHost(host);
-  res.type('application/xml').send(buildSitemapXml(req, host, siteConfig));
+  res.type('application/xml').send(await buildSitemapXml(req, host, siteConfig));
 });
 
 const draftsFolder = resolveDraftsFolder();


### PR DESCRIPTION
Promote block-authored HTML to a safe block host and improve SEO & sitemap behavior.

- generic-text: restructure template and logic to distinguish raw text vs HTML, detect block-level HTML with a regex, and return a 'div' host when HTML contains block elements; support innerHTML for individual tags; update unit tests to assert div-hosting of block HTML and id composition.
- seo-metadata: prefer configured canonical origin for fallbacks, normalize pathname, derive canonicalUrl and use it as the fallback for og:url and canonical link; add unit test verifying og:url uses the canonical page URL when openGraph url is missing.
- server: add dirname import, add local/runtime page-config loaders, async sitemap builder that resolves per-route canonical URLs (preferring page-config.seo.canonical) and dedupes sitemap entries by resolved canonical URL; several helper types and functions added.
- docs & infra: add SSR hydration/canonical-sitemap constraints note and an operations lesson, and ignore /reports/ in .gitignore.

These changes address invalid SSR-to-hydration markup from inline hosts, ensure og:url falls back to intended canonical URLs, and make sitemap generation collapse alias routes to the canonical URL.