### PR TITLE
Reuse hydrated site config for aliased domains

### DIFF
--- a/src/app/shared/services/config-source.service.spec.ts
+++ b/src/app/shared/services/config-source.service.spec.ts
@@ -11,6 +11,7 @@ import { environment } from '@/environments/environment';
 import { TestBed } from '@angular/core/testing';
 import { ConfigApiService } from './config-api.service';
 import { ConfigSourceService } from './config-source.service';
+import { ConfigStoreService } from './config-store.service';
 import { DraftConfigLoaderService } from './draft-config-loader.service';
 import { LanguageService } from './language.service';
 
@@ -164,6 +165,7 @@ describe('ConfigSourceService', () => {
                     provide: DraftConfigLoaderService,
                     useValue: {},
                 },
+                ConfigStoreService,
                 {
                     provide: LanguageService,
                     useValue: {
@@ -255,5 +257,34 @@ describe('ConfigSourceService', () => {
         await service.loadComponents('alecfest-voliii.zoolandingpage.com.mx', 'default');
 
         expect(api.getRuntimeBundle.calls.count()).toBe(1);
+    });
+
+    it('reuses the hydrated site config instead of calling the legacy site-config endpoint when the browser runtime bundle request fails', async () => {
+        const service = TestBed.inject(ConfigSourceService);
+        const api = TestBed.inject(ConfigApiService) as jasmine.SpyObj<ConfigApiService>;
+        const store = TestBed.inject(ConfigStoreService);
+
+        api.getRuntimeBundle.and.rejectWith(new Error('socket hang up'));
+        store.setSiteConfig(siteConfigPayload);
+
+        const result = await service.loadSiteConfig('alecfest-voliii.zoolandingpage.com.mx');
+
+        expect(result).toEqual(siteConfigPayload);
+        expect(api.getSiteConfig).not.toHaveBeenCalled();
+    });
+
+    it('still falls back to the legacy site-config endpoint when the runtime bundle request fails for the canonical domain', async () => {
+        const service = TestBed.inject(ConfigSourceService);
+        const api = TestBed.inject(ConfigApiService) as jasmine.SpyObj<ConfigApiService>;
+        const store = TestBed.inject(ConfigStoreService);
+
+        api.getRuntimeBundle.and.rejectWith(new Error('socket hang up'));
+        api.getSiteConfig.and.resolveTo(siteConfigPayload);
+        store.setSiteConfig(siteConfigPayload);
+
+        const result = await service.loadSiteConfig('alecfest-voliii.com');
+
+        expect(result).toEqual(siteConfigPayload);
+        expect(api.getSiteConfig).toHaveBeenCalledOnceWith('alecfest-voliii.com');
     });
 });

--- a/src/app/shared/services/config-source.service.ts
+++ b/src/app/shared/services/config-source.service.ts
@@ -12,6 +12,7 @@ import { environment } from '@/environments/environment';
 import { inject, Injectable, REQUEST } from '@angular/core';
 import { ConfigApiService } from './config-api.service';
 import { DraftConfigLoaderService } from './draft-config-loader.service';
+import { ConfigStoreService } from './config-store.service';
 import { LanguageService } from './language.service';
 
 type TConfigSource = {
@@ -29,6 +30,7 @@ export class ConfigSourceService {
     private readonly drafts = inject(DraftConfigLoaderService);
     private readonly request = inject(REQUEST, { optional: true });
     private readonly language = inject(LanguageService);
+    private readonly store = inject(ConfigStoreService);
     private readonly runtimeBundleCache = new Map<string, Promise<TRuntimeBundlePayload | null>>();
 
     private readonly draftSource: TConfigSource = {
@@ -52,7 +54,7 @@ export class ConfigSourceService {
     private readonly apiSource: TConfigSource = {
         loadSiteConfig: async (domain) => {
             const bundle = await this.tryLoadRuntimeBundle(domain);
-            return bundle?.siteConfig ?? this.legacyApiSource.loadSiteConfig(domain);
+            return bundle?.siteConfig ?? this.resolveHydratedAliasedSiteConfig(domain) ?? this.legacyApiSource.loadSiteConfig(domain);
         },
         loadPageConfig: async (domain, pageId) => {
             const bundle = await this.tryLoadRuntimeBundle(domain, { pageId });
@@ -238,6 +240,32 @@ export class ConfigSourceService {
             domain: domain || requestedDomain,
             pageId: pageId || requestedPageId,
         };
+    }
+
+    private normalizeDomainToken(value: unknown): string {
+        return String(value ?? '').trim().toLowerCase();
+    }
+
+    private resolveHydratedAliasedSiteConfig(requestedDomain: string): TDraftSiteConfigPayload | null {
+        if (this.request) {
+            return null;
+        }
+
+        const siteConfig = this.store.siteConfig();
+        if (!siteConfig) {
+            return null;
+        }
+
+        const normalizedRequestedDomain = this.normalizeDomainToken(requestedDomain);
+        if (!normalizedRequestedDomain) {
+            return null;
+        }
+
+        const normalizedAliases = Array.isArray(siteConfig.aliases)
+            ? siteConfig.aliases.map((alias) => this.normalizeDomainToken(alias)).filter(Boolean)
+            : [];
+
+        return normalizedAliases.includes(normalizedRequestedDomain) ? siteConfig : null;
     }
 
     private get source(): TConfigSource {


### PR DESCRIPTION
When the runtime bundle request fails, check the client-side hydrated ConfigStore for an aliased site config before falling back to the legacy site-config API. Inject ConfigStoreService, add normalizeDomainToken and resolveHydratedAliasedSiteConfig helpers, and wire that into the API source path. This only applies on the browser (not during server requests). Unit tests were added to verify reusing the hydrated config for aliased domains and still calling the legacy endpoint for the canonical domain when appropriate.