### PR TITLE
Promote configurable 404 to production

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -46,6 +46,8 @@
                 "zoolandingpage.com",
                 "sulandingpage.com.mx",
                 "sulandingpage.com",
+                "zoositioweb.com.mx",
+                "test.zoositioweb.com.mx",
                 "*.zoolandingpage.com.mx",
                 "lynxpardelle.com",
                 "*.lynxpardelle.com"
@@ -101,7 +103,9 @@
           "options": {
             "allowedHosts": [
               "localhost",
-              "127.0.0.1"
+              "127.0.0.1",
+              "zoositioweb.com.mx",
+              "test.zoositioweb.com.mx"
             ]
           },
           "configurations": {

--- a/docs/api-driven-config/schemas/site-config.schema.json
+++ b/docs/api-driven-config/schemas/site-config.schema.json
@@ -497,6 +497,7 @@
     "version": { "type": "integer", "minimum": 1 },
     "domain": { "type": "string", "minLength": 1 },
     "defaultPageId": { "type": "string" },
+    "notFoundPageId": { "type": "string" },
     "routes": {
       "type": "array",
       "items": { "$ref": "#/definitions/siteRouteEntry" }

--- a/src/app/shared/services/draft-runtime.service.spec.ts
+++ b/src/app/shared/services/draft-runtime.service.spec.ts
@@ -76,10 +76,57 @@ describe('DraftRuntimeService', () => {
     nativeHistoryReplaceState.call(window.history, {}, '', `${ nextUrl.pathname }${ nextUrl.search }${ nextUrl.hash }`);
   };
 
-  const configure = (requestUrl: string, siteConfig: unknown = null, options?: { browserMode?: boolean }) => {
+  const validPageConfig = (domain: string, pageId: string) => ({
+    version: 1,
+    domain,
+    pageId,
+    rootIds: ['root'],
+  });
+
+  const validComponents = (domain: string, pageId: string) => ({
+    version: 1,
+    domain,
+    pageId,
+    components: [
+      {
+        id: 'root',
+        type: 'container',
+        config: {},
+      },
+    ],
+  });
+
+  const configure = (
+    requestUrl: string,
+    siteConfig: unknown = null,
+    options?: {
+      browserMode?: boolean;
+      pageConfigByKey?: Record<string, unknown | null>;
+      componentsByKey?: Record<string, unknown | null>;
+    },
+  ) => {
     let nextUrl = new URL(requestUrl);
     setBrowserUrl(requestUrl);
-    const loadSiteConfig = jasmine.createSpy('loadSiteConfig').and.resolveTo(siteConfig);
+    const resolveSiteConfig = typeof siteConfig === 'function'
+      ? siteConfig as (domain: string) => unknown
+      : () => siteConfig;
+    const loadSiteConfig = jasmine.createSpy('loadSiteConfig').and.callFake((domain: string) => Promise.resolve(resolveSiteConfig(domain)));
+    const loadPageConfig = jasmine.createSpy('loadPageConfig').and.callFake((domain: string, pageId: string) => {
+      const key = `${ domain }::${ pageId }`;
+      if (options?.pageConfigByKey && key in options.pageConfigByKey) {
+        return Promise.resolve(options.pageConfigByKey[key]);
+      }
+
+      return Promise.resolve(validPageConfig(domain, pageId));
+    });
+    const loadComponents = jasmine.createSpy('loadComponents').and.callFake((domain: string, pageId: string) => {
+      const key = `${ domain }::${ pageId }`;
+      if (options?.componentsByKey && key in options.componentsByKey) {
+        return Promise.resolve(options.componentsByKey[key]);
+      }
+
+      return Promise.resolve(validComponents(domain, pageId));
+    });
 
     const providers: any[] = [
       DraftRuntimeService,
@@ -101,6 +148,8 @@ describe('DraftRuntimeService', () => {
         provide: ConfigSourceService,
         useValue: {
           loadSiteConfig,
+          loadPageConfig,
+          loadComponents,
         },
       },
     ];
@@ -138,6 +187,8 @@ describe('DraftRuntimeService', () => {
     return {
       service,
       loadSiteConfig,
+      loadPageConfig,
+      loadComponents,
       setUrl,
     };
   };
@@ -213,7 +264,55 @@ describe('DraftRuntimeService', () => {
     expect(service.activeDraftPageId()).toBe('contactame');
   });
 
-  it('falls back to defaultPageId when the current route is not mapped in site-config', async () => {
+  it('keeps the root route on the draft default page', async () => {
+    const { service } = configure(
+      'https://test.zoolandingpage.com.mx/?draftDomain=pamelabetancourt.com',
+      {
+        version: 1,
+        domain: 'pamelabetancourt.com',
+        defaultPageId: 'home',
+        notFoundPageId: 'not-found',
+        routes: [
+          { path: '/', pageId: 'home' },
+          { path: '/404', pageId: 'not-found' },
+        ],
+      },
+    );
+
+    const context = await service.resolveActiveDraftContext();
+
+    expect(context.pageId).toBe('home');
+    expect(context.path).toBe('/');
+    expect(service.activeDraftPageId()).toBe('home');
+  });
+
+  it('uses the configured notFoundPageId when the current route is not mapped in site-config', async () => {
+    const { service, loadPageConfig, loadComponents } = configure(
+      'https://test.zoolandingpage.com.mx/no-existe?draftDomain=pamelabetancourt.com',
+      {
+        version: 1,
+        domain: 'pamelabetancourt.com',
+        defaultPageId: 'home',
+        notFoundPageId: 'not-found',
+        routes: [
+          { path: '/', pageId: 'home' },
+          { path: '/servicios', pageId: 'servicios' },
+          { path: '/404', pageId: 'not-found' },
+        ],
+      },
+    );
+
+    const context = await service.resolveActiveDraftContext();
+
+    expect(context.pageId).toBe('not-found');
+    expect(context.path).toBe('/no-existe');
+    expect(context.route?.path).toBe('/404');
+    expect(service.activeDraftPageId()).toBe('not-found');
+    expect(loadPageConfig).toHaveBeenCalledWith('pamelabetancourt.com', 'not-found');
+    expect(loadComponents).toHaveBeenCalledWith('pamelabetancourt.com', 'not-found');
+  });
+
+  it('uses the /404 route as the draft not-found page when notFoundPageId is omitted', async () => {
     const { service } = configure(
       'https://test.zoolandingpage.com.mx/no-existe?draftDomain=pamelabetancourt.com',
       {
@@ -223,15 +322,55 @@ describe('DraftRuntimeService', () => {
         routes: [
           { path: '/', pageId: 'home' },
           { path: '/servicios', pageId: 'servicios' },
+          { path: '/404', pageId: 'not-found' },
         ],
       },
     );
 
     const context = await service.resolveActiveDraftContext();
 
-    expect(context.pageId).toBe('home');
+    expect(context.pageId).toBe('not-found');
     expect(context.path).toBe('/no-existe');
-    expect(service.activeDraftPageId()).toBe('home');
+    expect(service.activeDraftPageId()).toBe('not-found');
+  });
+
+  it('falls back to the canonical Zoolanding 404 when the draft cannot resolve a valid not-found page', async () => {
+    const { service } = configure(
+      'https://test.zoolandingpage.com.mx/no-existe?draftDomain=missing404.example.com',
+      (domain: string) => {
+        if (domain === 'missing404.example.com') {
+          return {
+            version: 1,
+            domain,
+            defaultPageId: 'home',
+            routes: [
+              { path: '/', pageId: 'home' },
+            ],
+          };
+        }
+
+        if (domain === 'zoolandingpage.com.mx') {
+          return {
+            version: 1,
+            domain,
+            defaultPageId: 'default',
+            notFoundPageId: 'not-found',
+            routes: [
+              { path: '/', pageId: 'default' },
+              { path: '/404', pageId: 'not-found' },
+            ],
+          };
+        }
+
+        return null;
+      },
+    );
+
+    const context = await service.resolveActiveDraftContext();
+
+    expect(context.domain).toBe('zoolandingpage.com.mx');
+    expect(context.pageId).toBe('not-found');
+    expect(context.path).toBe('/no-existe');
   });
 
   it('ignores cross-draft domain query params on branded production hosts', async () => {

--- a/src/app/shared/services/draft-runtime.service.ts
+++ b/src/app/shared/services/draft-runtime.service.ts
@@ -2,7 +2,7 @@ import { environment } from '@/environments/environment';
 import { isPlatformBrowser } from '@angular/common';
 import { computed, DestroyRef, inject, Injectable, NgZone, PLATFORM_ID, REQUEST, signal } from '@angular/core';
 import { navigateInCurrentWindow } from '../utility/navigation/browser-navigation.utility';
-import type { TDraftSiteConfigPayload, TDraftSiteRouteEntry } from '../types/config-payloads.types';
+import type { TComponentsPayload, TDraftSiteConfigPayload, TDraftSiteRouteEntry, TPageConfigPayload } from '../types/config-payloads.types';
 import { ConfigSourceService } from './config-source.service';
 import { ConfigStoreService } from './config-store.service';
 import { DomainResolverService } from './domain-resolver.service';
@@ -12,6 +12,7 @@ import { RuntimeConfigService } from './runtime-config.service';
 export const DRAFT_RUNTIME_STICKY_QUERY_PARAMS = ['draftDomain', 'debugWorkspace', 'lang'] as const;
 const INTERNAL_DEBUG_DRAFT_DOMAIN = '_debug';
 const INTERNAL_DEBUG_DRAFT_PAGE_ID = 'debug-workspace';
+const CANONICAL_NOT_FOUND_DOMAIN = 'zoolandingpage.com.mx';
 
 export type TDraftOption = TDraftRegistryEntry & {
     readonly key: string;
@@ -24,6 +25,12 @@ export type TResolvedDraftContext = {
     readonly path: string;
     readonly route: TDraftSiteRouteEntry | null;
     readonly explicitPageId: boolean;
+    readonly notFound?: boolean;
+};
+
+type TNotFoundResolution = {
+    readonly context: TResolvedDraftContext;
+    readonly siteConfig: TDraftSiteConfigPayload | null;
 };
 
 @Injectable({ providedIn: 'root' })
@@ -190,8 +197,20 @@ export class DraftRuntimeService {
         const domain = this.activeDraftDomain();
         const explicitPageId = this.hasExplicitDraftPageId();
         const path = this.resolvePathname();
+        if (!domain) {
+            const emptyContext = {
+                domain: '',
+                pageId: '',
+                path,
+                route: null,
+                explicitPageId: false,
+            } satisfies TResolvedDraftContext;
+            this.configStore.setSiteConfig(null);
+            this.applyResolvedContext(emptyContext);
+            return emptyContext;
+        }
+
         const siteConfig = await this.loadSiteConfig(domain);
-        this.configStore.setSiteConfig(siteConfig);
 
         if (explicitPageId) {
             const explicitContext = {
@@ -201,19 +220,57 @@ export class DraftRuntimeService {
                 route: null,
                 explicitPageId: true,
             } satisfies TResolvedDraftContext;
+            this.configStore.setSiteConfig(siteConfig);
             this.applyResolvedContext(explicitContext);
             return explicitContext;
         }
 
         const route = this.matchRoute(siteConfig, path);
+        if (route) {
+            const resolvedContext = {
+                domain,
+                pageId: route.pageId,
+                path,
+                route,
+                explicitPageId: false,
+            } satisfies TResolvedDraftContext;
+
+            this.configStore.setSiteConfig(siteConfig);
+            this.applyResolvedContext(resolvedContext);
+            return resolvedContext;
+        }
+
+        if (siteConfig && this.normalizePath(path) === '/') {
+            const resolvedContext = {
+                domain,
+                pageId: siteConfig.defaultPageId || this.requestedDraftPageId(),
+                path,
+                route: null,
+                explicitPageId: false,
+            } satisfies TResolvedDraftContext;
+
+            this.configStore.setSiteConfig(siteConfig);
+            this.applyResolvedContext(resolvedContext);
+            return resolvedContext;
+        }
+
+        const notFoundResolution = await this.resolveNotFoundContext(domain, path, siteConfig)
+            ?? await this.resolveCanonicalNotFoundContext(path);
+        if (notFoundResolution) {
+            this.configStore.setSiteConfig(notFoundResolution.siteConfig);
+            this.applyResolvedContext(notFoundResolution.context);
+            return notFoundResolution.context;
+        }
+
         const resolvedContext = {
             domain,
-            pageId: route?.pageId || siteConfig?.defaultPageId || this.requestedDraftPageId(),
+            pageId: '',
             path,
-            route,
+            route: null,
             explicitPageId: false,
         } satisfies TResolvedDraftContext;
 
+        this.configStore.setSiteConfig(siteConfig);
         this.applyResolvedContext(resolvedContext);
         return resolvedContext;
     }
@@ -417,6 +474,81 @@ export class DraftRuntimeService {
 
         const normalizedPath = this.normalizePath(path);
         return siteConfig.routes.find((entry) => this.normalizePath(entry.path) === normalizedPath) ?? null;
+    }
+
+    private matchRouteByPageId(siteConfig: TDraftSiteConfigPayload | null, pageId: string): TDraftSiteRouteEntry | null {
+        const normalizedPageId = String(pageId ?? '').trim();
+        if (!normalizedPageId || !siteConfig?.routes?.length) {
+            return null;
+        }
+
+        return siteConfig.routes.find((entry) => String(entry.pageId ?? '').trim() === normalizedPageId) ?? null;
+    }
+
+    private resolveNotFoundPageId(siteConfig: TDraftSiteConfigPayload | null): string {
+        const configured = String(siteConfig?.notFoundPageId ?? '').trim();
+        if (configured) {
+            return configured;
+        }
+
+        return String(this.matchRoute(siteConfig, '/404')?.pageId ?? '').trim();
+    }
+
+    private hasExpectedPagePayload(domain: string, pageId: string, pageConfig: TPageConfigPayload | null, components: TComponentsPayload | null): boolean {
+        const normalizedDomain = String(domain ?? '').trim();
+        const normalizedPageId = String(pageId ?? '').trim();
+        if (!normalizedDomain || !normalizedPageId) {
+            return false;
+        }
+
+        return String(pageConfig?.pageId ?? '').trim() === normalizedPageId
+            && Array.isArray(pageConfig?.rootIds)
+            && pageConfig.rootIds.length > 0
+            && String(components?.pageId ?? '').trim() === normalizedPageId
+            && Array.isArray(components?.components)
+            && components.components.length > 0;
+    }
+
+    private async canRenderPage(domain: string, pageId: string): Promise<boolean> {
+        try {
+            const [pageConfig, components] = await Promise.all([
+                this.configSource.loadPageConfig(domain, pageId),
+                this.configSource.loadComponents(domain, pageId),
+            ]);
+
+            return this.hasExpectedPagePayload(domain, pageId, pageConfig, components);
+        } catch {
+            return false;
+        }
+    }
+
+    private async resolveNotFoundContext(
+        domain: string,
+        path: string,
+        siteConfig: TDraftSiteConfigPayload | null,
+    ): Promise<TNotFoundResolution | null> {
+        const normalizedDomain = String(domain ?? '').trim();
+        const pageId = this.resolveNotFoundPageId(siteConfig);
+        if (!normalizedDomain || !pageId || !(await this.canRenderPage(normalizedDomain, pageId))) {
+            return null;
+        }
+
+        return {
+            siteConfig,
+            context: {
+                domain: normalizedDomain,
+                pageId,
+                path,
+                route: this.matchRouteByPageId(siteConfig, pageId),
+                explicitPageId: false,
+                notFound: true,
+            },
+        };
+    }
+
+    private async resolveCanonicalNotFoundContext(path: string): Promise<TNotFoundResolution | null> {
+        const siteConfig = await this.loadSiteConfig(CANONICAL_NOT_FOUND_DOMAIN);
+        return this.resolveNotFoundContext(CANONICAL_NOT_FOUND_DOMAIN, path, siteConfig);
     }
 
     private applyResolvedContext(context: TResolvedDraftContext): void {

--- a/src/app/shared/types/config-payloads.types.ts
+++ b/src/app/shared/types/config-payloads.types.ts
@@ -346,6 +346,7 @@ export type TDraftSiteConfigPayload = {
     readonly domain: string;
     readonly aliases?: readonly string[];
     readonly defaultPageId?: string;
+    readonly notFoundPageId?: string;
     readonly routes: readonly TDraftSiteRouteEntry[];
     readonly sitemap?: TDraftSitemapConfig;
     readonly lifecycle?: TSiteLifecycleConfig;
@@ -359,6 +360,7 @@ export type TConfigRegistryPayload = {
     readonly domain: string;
     readonly aliases?: readonly string[];
     readonly defaultPageId?: string;
+    readonly notFoundPageId?: string;
     readonly routes: readonly TDraftSiteRouteEntry[];
     readonly lifecycle: TSiteLifecycleConfig;
     readonly draft?: TConfigVersionPointer;

--- a/src/app/shared/utility/config-validation/config-payload.validators.spec.ts
+++ b/src/app/shared/utility/config-validation/config-payload.validators.spec.ts
@@ -166,6 +166,27 @@ describe('config-payload.validators', () => {
         expect(isDraftSiteConfigPayload(valid)).toBeTrue();
     });
 
+    it('accepts configurable draft not-found page ids in site-config payloads', () => {
+        const valid = {
+            version: 1,
+            domain: TEST_DOMAIN,
+            defaultPageId: 'default',
+            notFoundPageId: 'not-found',
+            routes: [
+                { path: '/', pageId: 'default' },
+                { path: '/404', pageId: 'not-found' },
+            ],
+            site: minimalSiteConfig(),
+        };
+        const invalid = {
+            ...valid,
+            notFoundPageId: 404,
+        };
+
+        expect(isDraftSiteConfigPayload(valid)).toBeTrue();
+        expect(isDraftSiteConfigPayload(invalid)).toBeFalse();
+    });
+
     it('accepts runtime data sources and api actions in site-config payloads', () => {
         const valid = {
             version: 1,

--- a/src/app/shared/utility/config-validation/config-payload.validators.ts
+++ b/src/app/shared/utility/config-validation/config-payload.validators.ts
@@ -1466,6 +1466,7 @@ export const isDraftSiteConfigPayload = (value: unknown): value is TDraftSiteCon
     if (typeof value['domain'] !== 'string') return false;
     if (value['aliases'] !== undefined && !isStringArray(value['aliases'])) return false;
     if (value['defaultPageId'] !== undefined && typeof value['defaultPageId'] !== 'string') return false;
+    if (value['notFoundPageId'] !== undefined && typeof value['notFoundPageId'] !== 'string') return false;
     if (!Array.isArray(value['routes']) || !value['routes'].every(isDraftSiteRouteEntry)) return false;
     if (value['lifecycle'] !== undefined && !isSiteLifecycleConfig(value['lifecycle'])) return false;
     if (value['runtime'] !== undefined && !isDraftSiteRuntimeConfig(value['runtime'])) return false;
@@ -1481,6 +1482,7 @@ export const isConfigRegistryPayload = (value: unknown): value is TConfigRegistr
     if (typeof value['domain'] !== 'string') return false;
     if (value['aliases'] !== undefined && !isStringArray(value['aliases'])) return false;
     if (value['defaultPageId'] !== undefined && typeof value['defaultPageId'] !== 'string') return false;
+    if (value['notFoundPageId'] !== undefined && typeof value['notFoundPageId'] !== 'string') return false;
     if (!Array.isArray(value['routes']) || !value['routes'].every(isDraftSiteRouteEntry)) return false;
     if (!isSiteLifecycleConfig(value['lifecycle'])) return false;
     if (value['draft'] !== undefined && !isConfigVersionPointer(value['draft'])) return false;

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,7 @@ const DEFAULT_CONFIG_API_URL = String(process.env['CONFIG_API_URL'] ?? 'https://
 const LOCAL_NOTE_FOLDER_NAMES = new Set(['ai_notes', 'findings', 'errors-reports']);
 const SITE_CONFIG_CACHE_TTL_MS = 60_000;
 const SITE_CONFIG_CACHE_MAX_SIZE = 200;
+const CANONICAL_NOT_FOUND_DOMAIN = 'zoolandingpage.com.mx';
 
 type TSiteConfigCacheEntry = {
   readonly path: string | null;
@@ -84,6 +85,7 @@ type TLocalSiteConfig = Record<string, unknown> & {
   readonly domain?: string;
   readonly aliases?: readonly string[];
   readonly defaultPageId?: string;
+  readonly notFoundPageId?: string;
   readonly routes?: readonly TSiteConfigRouteEntry[];
   readonly sitemap?: {
     readonly urls?: readonly string[];
@@ -104,7 +106,7 @@ type TLocalRuntimeBundlePayload = {
   readonly sourceStage: 'draft';
   readonly lang?: string;
   readonly generatedAt: string;
-  readonly route?: TSiteConfigRouteEntry;
+  readonly route?: TSiteConfigRouteEntry | null;
   readonly lifecycle?: unknown;
   readonly siteConfig: TLocalSiteConfig;
   readonly pageConfig: TLocalPageConfig;
@@ -113,6 +115,18 @@ type TLocalRuntimeBundlePayload = {
   readonly angoraCombos?: TLocalAngoraCombosPayload | null;
   readonly i18n?: TLocalI18nPayload | null;
   readonly metadata: Record<string, unknown>;
+};
+
+type TLocalRuntimePageResolution = {
+  readonly requestedDomain: string;
+  readonly loadDomain: string;
+  readonly resolvedDomain: string;
+  readonly pageId: string;
+  readonly route: TSiteConfigRouteEntry | null;
+  readonly siteConfig: TLocalSiteConfig;
+  readonly statusCode: 200 | 404;
+  readonly notFound: boolean;
+  readonly fallbackFromDomain?: string;
 };
 
 const siteConfigPathCache = new Map<string, TSiteConfigCacheEntry>();
@@ -153,6 +167,11 @@ function normalizeHost(value: unknown): string {
     .trim()
     .toLowerCase()
     .replace(/:\d+$/, '');
+}
+
+function isLocalHost(value: unknown): boolean {
+  const normalized = normalizeHost(value);
+  return normalized === 'localhost' || normalized === '127.0.0.1' || normalized === '::1';
 }
 
 function normalizeRoutePath(value: unknown): string {
@@ -468,6 +487,116 @@ function resolveLocalRuntimePageId(siteConfig: TLocalSiteConfig | null, path: st
   return String(route?.pageId ?? siteConfig?.defaultPageId ?? 'default').trim() || 'default';
 }
 
+function resolveLocalNotFoundPageId(siteConfig: TLocalSiteConfig | null): string {
+  const configured = String(siteConfig?.notFoundPageId ?? '').trim();
+  if (configured) {
+    return configured;
+  }
+
+  return String(resolveLocalRoute(siteConfig, '/404')?.pageId ?? '').trim();
+}
+
+function hasRenderableLocalPage(domain: string, pageId: string): boolean {
+  const pageConfig = loadLocalPageConfig(domain, pageId);
+  const components = loadLocalComponents(domain, pageId);
+  return String(pageConfig?.pageId ?? '').trim() === pageId
+    && Array.isArray(pageConfig?.rootIds)
+    && pageConfig.rootIds.length > 0
+    && String(components?.pageId ?? '').trim() === pageId
+    && Array.isArray(components?.components)
+    && components.components.length > 0;
+}
+
+function resolveLocalNotFoundRuntimePage(
+  loadDomain: string,
+  siteConfig: TLocalSiteConfig | null,
+  requestedDomain: string,
+  fallbackFromDomain?: string,
+): TLocalRuntimePageResolution | null {
+  const pageId = resolveLocalNotFoundPageId(siteConfig);
+  if (!siteConfig || !pageId || !hasRenderableLocalPage(loadDomain, pageId)) {
+    return null;
+  }
+
+  const resolvedDomain = String(siteConfig.domain ?? loadDomain).trim() || loadDomain;
+  return {
+    requestedDomain,
+    loadDomain,
+    resolvedDomain,
+    pageId,
+    route: resolveLocalRoute(siteConfig, '/404', pageId) ?? null,
+    siteConfig,
+    statusCode: 404,
+    notFound: true,
+    fallbackFromDomain,
+  };
+}
+
+function resolveCanonicalLocalNotFoundRuntimePage(requestedDomain: string): TLocalRuntimePageResolution | null {
+  const siteConfig = loadLocalSiteConfig(CANONICAL_NOT_FOUND_DOMAIN);
+  return resolveLocalNotFoundRuntimePage(
+    CANONICAL_NOT_FOUND_DOMAIN,
+    siteConfig,
+    requestedDomain,
+    requestedDomain === CANONICAL_NOT_FOUND_DOMAIN ? undefined : requestedDomain,
+  );
+}
+
+function resolveLocalRuntimePage(opts: {
+  readonly requestedDomain: string;
+  readonly siteConfig: TLocalSiteConfig;
+  readonly path: string;
+  readonly pageId?: string;
+}): TLocalRuntimePageResolution | null {
+  const explicitPageId = String(opts.pageId ?? '').trim();
+  const normalizedPath = normalizeRoutePath(opts.path);
+  const resolvedDomain = String(opts.siteConfig.domain ?? opts.requestedDomain).trim() || opts.requestedDomain;
+
+  if (explicitPageId) {
+    return {
+      requestedDomain: opts.requestedDomain,
+      loadDomain: opts.requestedDomain,
+      resolvedDomain,
+      pageId: explicitPageId,
+      route: resolveLocalRoute(opts.siteConfig, normalizedPath, explicitPageId) ?? null,
+      siteConfig: opts.siteConfig,
+      statusCode: 200,
+      notFound: false,
+    };
+  }
+
+  const route = resolveLocalRoute(opts.siteConfig, normalizedPath);
+  if (route) {
+    const pageId = String(route.pageId ?? '').trim() || resolveLocalRuntimePageId(opts.siteConfig, normalizedPath);
+    return {
+      requestedDomain: opts.requestedDomain,
+      loadDomain: opts.requestedDomain,
+      resolvedDomain,
+      pageId,
+      route,
+      siteConfig: opts.siteConfig,
+      statusCode: 200,
+      notFound: false,
+    };
+  }
+
+  if (normalizedPath === '/') {
+    return {
+      requestedDomain: opts.requestedDomain,
+      loadDomain: opts.requestedDomain,
+      resolvedDomain,
+      pageId: String(opts.siteConfig.defaultPageId ?? 'default').trim() || 'default',
+      route: null,
+      siteConfig: opts.siteConfig,
+      statusCode: 200,
+      notFound: false,
+    };
+  }
+
+  return resolveLocalNotFoundRuntimePage(opts.requestedDomain, opts.siteConfig, opts.requestedDomain)
+    ?? resolveCanonicalLocalNotFoundRuntimePage(opts.requestedDomain);
+}
+
 function loadLocalRuntimeBundle(opts: {
   readonly domain: string;
   readonly pageId?: string;
@@ -479,21 +608,29 @@ function loadLocalRuntimeBundle(opts: {
     return null;
   }
 
+  const normalizedPath = normalizeRoutePath(opts.path);
   const siteConfig = loadLocalSiteConfig(requestedDomain);
-  if (!siteConfig) {
+  const resolution = siteConfig
+    ? resolveLocalRuntimePage({
+      requestedDomain,
+      siteConfig,
+      path: normalizedPath,
+      pageId: opts.pageId,
+    })
+    : resolveCanonicalLocalNotFoundRuntimePage(requestedDomain);
+  if (!resolution) {
     return null;
   }
 
-  const normalizedPath = normalizeRoutePath(opts.path);
-  const pageId = resolveLocalRuntimePageId(siteConfig, normalizedPath, opts.pageId);
-  const pageConfig = loadLocalPageConfig(requestedDomain, pageId);
-  const components = loadLocalComponents(requestedDomain, pageId);
+  const pageId = resolution.pageId;
+  const pageConfig = loadLocalPageConfig(resolution.loadDomain, pageId);
+  const components = loadLocalComponents(resolution.loadDomain, pageId);
   if (!pageConfig || !components) {
     return null;
   }
 
-  const resolvedDomain = String(siteConfig.domain ?? requestedDomain).trim() || requestedDomain;
-  const route = resolveLocalRoute(siteConfig, normalizedPath, pageId);
+  const resolvedDomain = resolution.resolvedDomain;
+  const route = resolution.route;
   const lang = String(opts.lang ?? '').trim() || 'es';
 
   return {
@@ -504,9 +641,9 @@ function loadLocalRuntimeBundle(opts: {
     lang,
     generatedAt: new Date().toISOString(),
     route,
-    lifecycle: siteConfig.lifecycle,
+    lifecycle: resolution.siteConfig.lifecycle,
     siteConfig: {
-      ...siteConfig,
+      ...resolution.siteConfig,
       domain: resolvedDomain,
     },
     pageConfig: {
@@ -519,13 +656,17 @@ function loadLocalRuntimeBundle(opts: {
       domain: resolvedDomain,
       pageId,
     },
-    variables: loadLocalVariables(requestedDomain, pageId),
-    angoraCombos: loadLocalAngoraCombos(requestedDomain, pageId),
-    i18n: loadLocalI18n(requestedDomain, pageId, lang),
+    variables: loadLocalVariables(resolution.loadDomain, pageId),
+    angoraCombos: loadLocalAngoraCombos(resolution.loadDomain, pageId),
+    i18n: loadLocalI18n(resolution.loadDomain, pageId, lang),
     metadata: {
       source: 'local-drafts',
       requestedDomain,
+      loadDomain: resolution.loadDomain,
       resolvedPath: normalizedPath,
+      statusCode: resolution.statusCode,
+      notFound: resolution.notFound,
+      fallbackFromDomain: resolution.fallbackFromDomain,
     },
   };
 }
@@ -616,6 +757,15 @@ function resolveRequestHost(req: express.Request): string {
   return normalizeHost(forwardedHost || req.headers.host);
 }
 
+function resolveNotFoundLookupDomain(req: express.Request, host: string): string {
+  const draftDomain = normalizeHost(req.query['draftDomain']);
+  if (isLocalHost(host) && draftDomain) {
+    return draftDomain;
+  }
+
+  return host;
+}
+
 function resolveRequestProtocol(req: express.Request, host: string): string {
   const forwardedProto = String(req.headers['x-forwarded-proto'] ?? '')
     .split(',')[0]
@@ -694,10 +844,17 @@ async function buildSitemapXml(req: express.Request, host: string, siteConfig: T
     (Array.isArray(siteConfig?.sitemap?.excludePaths) ? siteConfig.sitemap.excludePaths : [])
       .map((entry) => normalizeRoutePath(entry)),
   );
+  const notFoundPageId = resolveLocalNotFoundPageId(siteConfig);
   const rawRoutes = Array.isArray(siteConfig?.routes) && siteConfig.routes.length > 0
     ? siteConfig.routes
     : [{ path: '/' }];
-  const sitemapRoutes = rawRoutes.filter((route) => !excludedPaths.has(normalizeRoutePath(route.path)));
+  const sitemapRoutes = rawRoutes.filter((route) => {
+    const routePath = normalizeRoutePath(route.path);
+    const routePageId = String(route.pageId ?? '').trim();
+    return !excludedPaths.has(routePath)
+      && routePath !== '/404'
+      && (!notFoundPageId || routePageId !== notFoundPageId);
+  });
   const sitemapDomain = normalizeHost(host) || normalizeHost(siteConfig?.domain);
   const resolvedUrls = await Promise.all(sitemapRoutes.map(async (route) => {
     const pageConfig = sitemapDomain ? await loadPageConfigForRoute(sitemapDomain, route) : null;
@@ -717,6 +874,23 @@ async function buildSitemapXml(req: express.Request, host: string, siteConfig: T
     entries,
     '</urlset>',
   ].join('\n');
+}
+
+async function shouldServeNotFoundDocument(req: express.Request): Promise<boolean> {
+  const host = resolveRequestHost(req);
+  const lookupDomain = resolveNotFoundLookupDomain(req, host);
+  const normalizedPath = normalizeRoutePath(req.path);
+  const siteConfig = await loadSiteConfigForHost(lookupDomain);
+
+  if (!siteConfig) {
+    return (!isLocalHost(host) || lookupDomain !== host) && normalizedPath !== '/';
+  }
+
+  if (resolveLocalRoute(siteConfig, normalizedPath)) {
+    return false;
+  }
+
+  return normalizedPath !== '/';
 }
 
 function listDraftRegistryEntries(): readonly TDraftRegistryEntry[] {
@@ -868,11 +1042,25 @@ app.use(
  * Handle all other requests by rendering the Angular application.
  */
 app.use((req, res, next) => {
-  angularApp
-    .handle(req)
-    .then((response) =>
-      response ? writeResponseToNodeResponse(response, res) : next(),
-    )
+  shouldServeNotFoundDocument(req)
+    .then((notFoundDocument) => angularApp.handle(req)
+      .then((response) => {
+        if (!response) {
+          next();
+          return;
+        }
+
+        if (!notFoundDocument) {
+          writeResponseToNodeResponse(response, res);
+          return;
+        }
+
+        writeResponseToNodeResponse(new Response(response.body, {
+          headers: response.headers,
+          status: 404,
+          statusText: 'Not Found',
+        }), res);
+      }))
     .catch(next);
 });
 

--- a/tools/tests/draft-local-context.spec.mjs
+++ b/tools/tests/draft-local-context.spec.mjs
@@ -448,6 +448,149 @@ test('built SSR server hides local-only draft folders from registry and static s
   assert.match(sitemapXml, /<loc>https:\/\/fixture\.example\.com\/<\/loc>/);
 });
 
+test('built SSR server resolves configurable 404 runtime bundles and excludes 404 routes from sitemap', async t => {
+  assert.equal(
+    existsSync(builtServerPath),
+    true,
+    'Built SSR server not found. Run this test through `npm run test:draft-context` or build first.'
+  );
+
+  const workspaceRoot = await mkdtemp(path.join(tmpdir(), 'zoolanding-404-runtime-'));
+  const draftsRoot = path.join(workspaceRoot, 'drafts');
+
+  const writeDraftPage = async (domain, pageId, text) => {
+    const domainRoot = path.join(draftsRoot, domain);
+    await writeJson(path.join(domainRoot, pageId, 'page-config.json'), {
+      version: 1,
+      domain,
+      pageId,
+      rootIds: ['main'],
+      modalRootIds: [],
+    });
+    await writeJson(path.join(domainRoot, pageId, 'components.json'), {
+      version: 1,
+      domain,
+      pageId,
+      components: [
+        {
+          id: 'main',
+          type: 'text',
+          config: {
+            tag: 'main',
+            text,
+          },
+        },
+      ],
+    });
+  };
+
+  await writeJson(path.join(draftsRoot, 'fixture.example.com', 'site-config.json'), {
+    version: 1,
+    domain: 'fixture.example.com',
+    defaultPageId: 'default',
+    notFoundPageId: 'not-found',
+    routes: [
+      { path: '/', pageId: 'default' },
+      { path: '/404', pageId: 'not-found' },
+    ],
+    site: {
+      appIdentity: { identifier: 'fixture', name: 'Fixture Example' },
+      theme: { defaultMode: 'light', palettes: {} },
+      i18n: { defaultLanguage: 'en', supportedLanguages: [{ code: 'en', label: 'EN' }] },
+      seo: { canonicalOrigin: 'https://fixture.example.com' },
+    },
+  });
+  await writeDraftPage('fixture.example.com', 'default', 'Fixture home');
+  await writeDraftPage('fixture.example.com', 'not-found', 'Fixture custom 404');
+
+  await writeJson(path.join(draftsRoot, 'zoolandingpage.com.mx', 'site-config.json'), {
+    version: 1,
+    domain: 'zoolandingpage.com.mx',
+    defaultPageId: 'default',
+    notFoundPageId: 'not-found',
+    routes: [
+      { path: '/', pageId: 'default' },
+      { path: '/404', pageId: 'not-found' },
+    ],
+    site: {
+      appIdentity: { identifier: 'zoolandingpage', name: 'ZoolandingPage' },
+      theme: { defaultMode: 'light', palettes: {} },
+      i18n: { defaultLanguage: 'en', supportedLanguages: [{ code: 'en', label: 'EN' }] },
+      seo: { canonicalOrigin: 'https://zoolandingpage.com.mx' },
+    },
+  });
+  await writeDraftPage('zoolandingpage.com.mx', 'not-found', 'Canonical 404');
+
+  const port = await getFreePort();
+  const child = spawn(process.execPath, [builtServerPath], {
+    cwd: workspaceRoot,
+    env: {
+      ...process.env,
+      PORT: String(port),
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+
+  let serverOutput = '';
+  child.stdout.on('data', chunk => {
+    serverOutput += chunk.toString();
+  });
+  child.stderr.on('data', chunk => {
+    serverOutput += chunk.toString();
+  });
+
+  t.after(async () => {
+    await stopServer(child);
+    await rm(workspaceRoot, { recursive: true, force: true });
+  });
+
+  await waitForServer(`http://127.0.0.1:${port}/api/debug/drafts`);
+
+  const homeDocumentResponse = await fetch(`http://127.0.0.1:${port}/?draftDomain=fixture.example.com`);
+  assert.equal(homeDocumentResponse.status, 200, serverOutput);
+
+  const missingDocumentResponse = await fetch(`http://127.0.0.1:${port}/missing?draftDomain=fixture.example.com`);
+  assert.equal(missingDocumentResponse.status, 404, serverOutput);
+
+  const homeResponse = await fetch(`http://127.0.0.1:${port}/runtime-bundle?domain=fixture.example.com&path=/`);
+  assert.equal(homeResponse.status, 200, serverOutput);
+  const homePayload = await homeResponse.json();
+  assert.equal(homePayload.pageId, 'default');
+  assert.equal(homePayload.metadata.statusCode, 200);
+  assert.equal(homePayload.metadata.notFound, false);
+
+  const missingResponse = await fetch(`http://127.0.0.1:${port}/runtime-bundle?domain=fixture.example.com&path=/missing`);
+  assert.equal(missingResponse.status, 200, serverOutput);
+  const missingPayload = await missingResponse.json();
+  assert.equal(missingPayload.domain, 'fixture.example.com');
+  assert.equal(missingPayload.pageId, 'not-found');
+  assert.equal(missingPayload.route.path, '/404');
+  assert.equal(missingPayload.metadata.resolvedPath, '/missing');
+  assert.equal(missingPayload.metadata.statusCode, 404);
+  assert.equal(missingPayload.metadata.notFound, true);
+
+  const noConfigResponse = await fetch(`http://127.0.0.1:${port}/runtime-bundle?domain=no-config.example.com&path=/missing`);
+  assert.equal(noConfigResponse.status, 200, serverOutput);
+  const noConfigPayload = await noConfigResponse.json();
+  assert.equal(noConfigPayload.domain, 'zoolandingpage.com.mx');
+  assert.equal(noConfigPayload.pageId, 'not-found');
+  assert.equal(noConfigPayload.metadata.loadDomain, 'zoolandingpage.com.mx');
+  assert.equal(noConfigPayload.metadata.fallbackFromDomain, 'no-config.example.com');
+  assert.equal(noConfigPayload.metadata.statusCode, 404);
+
+  const sitemapResponse = await fetch(`http://127.0.0.1:${port}/sitemap.xml`, {
+    headers: {
+      'x-forwarded-host': 'fixture.example.com',
+      'x-forwarded-proto': 'https',
+    },
+  });
+  assert.equal(sitemapResponse.status, 200, serverOutput);
+  const sitemapXml = await sitemapResponse.text();
+  assert.match(sitemapXml, /<loc>https:\/\/fixture\.example\.com\/<\/loc>/);
+  assert.doesNotMatch(sitemapXml, /\/404<\/loc>/);
+});
+
 test('built SSR server can derive sitemap routes from the runtime bundle when local drafts are missing', async t => {
   assert.equal(
     existsSync(builtServerPath),


### PR DESCRIPTION
Promotes the configurable draft 404 runtime and draft 404 payloads from test to production after test QA passed.