### PR TITLE
Prevent CloudFront HTTPS redirect loops

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1342,17 +1342,50 @@ function isSharedTestingDraftPreviewRequest(req: express.Request, host: string):
 }
 
 function resolveRequestProtocol(req: express.Request, host: string): string {
+  const cloudFrontProtoValues = String(req.headers['cloudfront-forwarded-proto'] ?? '')
+    .split(',')
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
   const forwardedProtoValues = String(req.headers['x-forwarded-proto'] ?? '')
     .split(',')
     .map((value) => value.trim().toLowerCase())
     .filter(Boolean);
+  const forwardedPortValues = String(req.headers['x-forwarded-port'] ?? '')
+    .split(',')
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
+  const forwardedSslValues = String(req.headers['x-forwarded-ssl'] ?? '')
+    .split(',')
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
 
-  if (forwardedProtoValues.includes('https')) {
+  if (
+    cloudFrontProtoValues.includes('https')
+    || forwardedProtoValues.includes('https')
+    || forwardedPortValues.includes('443')
+    || forwardedSslValues.includes('on')
+  ) {
     return 'https';
+  }
+
+  if (cloudFrontProtoValues.length > 0) {
+    return cloudFrontProtoValues[0];
   }
 
   if (forwardedProtoValues.length > 0) {
     return forwardedProtoValues[0];
+  }
+
+  if (forwardedPortValues.includes('80')) {
+    return 'http';
+  }
+
+  if (forwardedSslValues.includes('off')) {
+    return 'http';
+  }
+
+  if (req.secure) {
+    return 'https';
   }
 
   return host === 'localhost' || host.startsWith('127.') ? 'http' : 'https';

--- a/tools/tests/ssr-server.spec.mjs
+++ b/tools/tests/ssr-server.spec.mjs
@@ -149,6 +149,49 @@ test('production SSR server does not self-redirect when proxy proto chain includ
   assert.equal(getStderr(), '');
 });
 
+test('production SSR server does not self-redirect when CloudFront viewer proto is https', async (t) => {
+  const { port, getStderr } = await startProductionServer(t);
+  const response = await fetch(`http://127.0.0.1:${port}/robots.txt`, {
+    redirect: 'manual',
+    headers: {
+      Host: 'test.zoolandingpage.com.mx',
+      'CloudFront-Forwarded-Proto': 'https',
+      'X-Forwarded-For': '203.0.113.10',
+      'X-Forwarded-Host': 'test.zoolandingpage.com.mx',
+      'X-Forwarded-Port': '80',
+      'X-Forwarded-Proto': 'http',
+      'X-Forwarded-Server': 'cloudfront',
+    },
+  });
+  const body = await response.text();
+
+  assert.equal(response.status, 200);
+  assert.match(body, /Sitemap: https:\/\/zoolandingpage\.com\.mx\/sitemap\.xml/);
+  assert.equal(response.headers.get('location'), null);
+  assert.equal(getStderr(), '');
+});
+
+test('production SSR server does not self-redirect when forwarded port is 443', async (t) => {
+  const { port, getStderr } = await startProductionServer(t);
+  const response = await fetch(`http://127.0.0.1:${port}/robots.txt`, {
+    redirect: 'manual',
+    headers: {
+      Host: 'test.zoolandingpage.com.mx',
+      'X-Forwarded-For': '203.0.113.10',
+      'X-Forwarded-Host': 'test.zoolandingpage.com.mx',
+      'X-Forwarded-Port': '443',
+      'X-Forwarded-Proto': 'http',
+      'X-Forwarded-Server': 'cloudfront',
+    },
+  });
+  const body = await response.text();
+
+  assert.equal(response.status, 200);
+  assert.match(body, /Sitemap: https:\/\/zoolandingpage\.com\.mx\/sitemap\.xml/);
+  assert.equal(response.headers.get('location'), null);
+  assert.equal(getStderr(), '');
+});
+
 test('production SSR server redirects proxy-forwarded http to https', async (t) => {
   const { port, getStderr } = await startProductionServer(t);
   const response = await fetch(`http://127.0.0.1:${port}/robots.txt`, {


### PR DESCRIPTION
Fixes the production redirect loop found during the post-promotion audit:

- Treat CloudFront viewer HTTPS as HTTPS even when the origin hop uses HTTP.
- Treat `X-Forwarded-Port: 443` and `X-Forwarded-SSL: on` as HTTPS signals.
- Keep redirecting explicit proxy-forwarded HTTP traffic to HTTPS.
- Adds SSR regressions for CloudFront and forwarded-port 443 cases.

Local verification:
- Node v24.15.0 `@angular/cli/bin/ng.js build`: passed.
- Node v24.15.0 `node --test tools/tests/ssr-server.spec.mjs`: 16/16 passed.