### PR TITLE
Promote analytics test isolation

### DIFF
--- a/src/app/shared/services/analytics.service.spec.ts
+++ b/src/app/shared/services/analytics.service.spec.ts
@@ -7,7 +7,32 @@ import { ConfigStoreService } from './config-store.service';
 import { QuickStatsService } from './quick-stats.service';
 import { RuntimeConfigService } from './runtime-config.service';
 
+const nativeHistoryPushState = History.prototype.pushState;
+const nativeHistoryReplaceState = History.prototype.replaceState;
+
+const restoreNativeHistoryStateMethods = (): void => {
+  Object.defineProperty(window.history, 'pushState', {
+    configurable: true,
+    writable: true,
+    value: nativeHistoryPushState.bind(window.history),
+  });
+  Object.defineProperty(window.history, 'replaceState', {
+    configurable: true,
+    writable: true,
+    value: nativeHistoryReplaceState.bind(window.history),
+  });
+};
+
+const setSpecUrl = (url: string): void => {
+  restoreNativeHistoryStateMethods();
+  window.history.replaceState({}, '', url);
+};
+
 describe('AnalyticsService', () => {
+  afterEach(() => {
+    setSpecUrl('/context.html');
+  });
+
   it('tracks events and buffers them', () => {
     TestBed.configureTestingModule({
       providers: [
@@ -313,9 +338,7 @@ describe('AnalyticsService', () => {
   });
 
   it('mirrors internal page views to Google dataLayer with stored ad attribution but without ad params in page_location', async () => {
-    const originalUrl = window.location.href;
     const attributionStorageKey = 'fixture:adAttribution';
-    const nativeReplaceState = History.prototype.replaceState;
     const trackingUrl = new URL(
       '/?gclid=test-gclid&utm_source=google&utm_campaign=spring&email=lead@example.com',
       window.location.origin,
@@ -328,7 +351,7 @@ describe('AnalyticsService', () => {
 
     try {
       window.sessionStorage.removeItem(attributionStorageKey);
-      nativeReplaceState.call(window.history, {}, '', trackingUrl);
+      setSpecUrl(trackingUrl);
       expect(window.location.href).toBe(trackingUrl);
 
       TestBed.configureTestingModule({
@@ -384,7 +407,7 @@ describe('AnalyticsService', () => {
       expect(pageView?.email).toBeUndefined();
     } finally {
       window.sessionStorage.removeItem(attributionStorageKey);
-      nativeReplaceState.call(window.history, {}, '', originalUrl);
+      setSpecUrl('/context.html');
       (window as any).dataLayer = [];
       delete (window as any).gtag;
     }


### PR DESCRIPTION
## Summary
- Promote the zoneless runner follow-up that isolates AnalyticsService spec browser history state.
- No production runtime code changes; build output remains the same bundle hash.

## Verification
- npm test -- --include=src/app/shared/services/analytics.service.spec.ts --progress=false: TOTAL: 19 SUCCESS
- npm test -- --progress=false: TOTAL: 468 SUCCESS
- npm run test:zoneless-runner: pass 4, fail 0
- npm run build: Application bundle generation complete
- npm run ssr:smoke: pass 16, fail 0
- node tools/draft-smoke-check.mjs --local-base-url=https://test.zoolandingpage.com.mx --include-live=true --timeout-ms=30000: Local failures: 0, Live mismatches: 0