### PR TITLE
promote: runtime alias health checks to test

### DIFF
--- a/changelog/app/2026-06.md
+++ b/changelog/app/2026-06.md
@@ -1,5 +1,11 @@
 # App Changelog - 2026-06
 
+## 2026-06-08 04:09 CT - Runtime alias health assertions
+
+- Added strict runtime alias assertions to `tools/ops/public-site-health-check.mjs` through the `--expected-runtime-domains=<host>=<domain>` option so public health checks can fail when a campaign alias returns `runtime.ok=true` but resolves to the wrong canonical draft or omits `metadata.resolvedAlias`.
+- Included `tools/tests/ops-public-site-health-check.spec.mjs` in `npm run test:ops-front-door` and added coverage for the missing-`resolvedAlias` case.
+- Rechecked the three Zoosite campaign aliases after runtime metadata/cache convergence. The direct runtime API returned `domain: "zoositioweb.com.mx"` with matching `resolvedAlias` values for `sitiosweb.zoolandingpage.com.mx`, `quierounsitioweb.zoolandingpage.com.mx`, and `crearpaginaweb.zoolandingpage.com.mx`.
+
 ## 2026-06-07 22:25 CT - Angular 22 and signal state foundation
 
 - Updated the app dependency baseline to Angular 22.0.x, TypeScript 6.0.x, and Node 24.15.0 for local migration commands.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test:draft-public-safety-audit": "node --test tools/tests/draft-public-safety-audit.spec.mjs",
     "test:draft-aws-oidc-setup": "node --test tools/tests/draft-aws-oidc-setup.spec.mjs",
     "test:draft-github-setup": "node --test tools/tests/draft-github-setup.spec.mjs",
-    "test:ops-front-door": "node --test tools/tests/ops-managed-alias-front-door.spec.mjs tools/tests/ops-runtime-front-door-probe.spec.mjs tools/tests/ops-runtime-front-door-cache.spec.mjs tools/tests/ops-runtime-observability.spec.mjs",
+    "test:ops-front-door": "node --test tools/tests/ops-managed-alias-front-door.spec.mjs tools/tests/ops-runtime-front-door-probe.spec.mjs tools/tests/ops-runtime-front-door-cache.spec.mjs tools/tests/ops-runtime-observability.spec.mjs tools/tests/ops-public-site-health-check.spec.mjs",
     "test:draft-context": "npm run build && node --test tools/tests/draft-local-context.spec.mjs",
     "ci:budgets": "node ./node_modules/@angular/cli/bin/ng.js build --configuration production",
     "ci:perf": "node tools/perf-baseline.mjs"

--- a/tools/tests/ops-public-site-health-check.spec.mjs
+++ b/tools/tests/ops-public-site-health-check.spec.mjs
@@ -93,3 +93,26 @@ test('checkRuntimeBundle passes when runtime resolves expected domain and alias'
     assert.equal(check.details.resolvedAlias, 'sitiosweb.zoolandingpage.com.mx');
   });
 });
+
+test('checkRuntimeBundle fails when expected alias resolution is missing', async () => {
+  await withRuntimeServer({
+    ok: true,
+    domain: 'zoositioweb.com.mx',
+    metadata: { resolvedAlias: null },
+    versionId: 'missing-alias',
+  }, async (runtimeBaseUrl) => {
+    const check = await checkRuntimeBundle('sitiosweb.zoolandingpage.com.mx', {
+      runtimeBaseUrl,
+      runtimeFallbackUrl: '',
+      timeoutMs: 1000,
+      retryAttempts: 1,
+      retryDelayMs: 0,
+      expectedRuntimeDomains: new Map([
+        ['sitiosweb.zoolandingpage.com.mx', 'zoositioweb.com.mx'],
+      ]),
+    });
+
+    assert.equal(check.ok, false);
+    assert.equal(check.details.reason, 'runtime-bundle did not report the expected resolved alias');
+  });
+});


### PR DESCRIPTION
## Summary
- Promote the runtime alias health-check follow-up from dev to test.
- Keeps npm run test:ops-front-door covering public-site runtime alias regressions.

## Verification before promotion
- npm run test:ops-front-door
- npm run ssr:smoke
- npm test -- --progress=false rerun filtered: TOTAL: 468 SUCCESS
- strict public health check for Zoosite campaign aliases returned ok: true and failed: []
- direct runtime API probe returned domain zoositioweb.com.mx and matching resolvedAlias for all three aliases