### PR TITLE
Promote release audit notes to production

### DIFF
--- a/changelog/app/2026-06.md
+++ b/changelog/app/2026-06.md
@@ -8,6 +8,10 @@
 - Added an `AngoraCombosService` mock to `generic-dropdown.component.spec.ts` and asserted the dropdown still requests a CSS refresh when opening the overlay.
 - Updated the AnalyticsService spec URL helper to call the captured native `History.prototype.replaceState` directly, avoiding cross-spec contamination from history spies when the full suite changes `window.history` methods.
 - Validation passed: focused `generic-dropdown.component.spec.ts` (`TOTAL: 6 SUCCESS`), focused `analytics.service.spec.ts` (`TOTAL: 19 SUCCESS`), focused `generic-input.component.spec.ts` (`TOTAL: 11 SUCCESS`), `npm run test:zoneless-runner` (`pass 5`), three consecutive full Karma runs (`TOTAL: 468 SUCCESS` each), `npm run build`, and `npm run ssr:smoke` (`pass 16`).
+- Promoted through PR #28 (`codex/karma-chrome-test-isolation` -> `dev`, merge `37ec3332dd777caa6c7947f20e5e88b0c002da39`), PR #29 (`dev` -> `test`, merge `f4d0894332c2031014c7d4f5a50524c1600fa44c`), and PR #30 (`test` -> `main`, merge `9be5ac405798c0a8ff4775a0d83e6f864e02ab16`).
+- Testing audit passed for the shared test host across the 11 registry drafts in desktop/mobile (`checked: 22`, `failures: []`), and `tools/ops/public-site-health-check.mjs --hosts=test.zoolandingpage.com.mx` returned `"ok": true` at `2026-06-08 05:18:15` CT.
+- Production public health passed for the live production hosts and Zoosite campaign aliases (`"ok": true`, `failed: []` at `2026-06-08 05:22:08` CT), including direct runtime alias assertions for `sitiosweb.zoolandingpage.com.mx`, `quierounsitioweb.zoolandingpage.com.mx`, and `crearpaginaweb.zoolandingpage.com.mx` resolving to `zoositioweb.com.mx`.
+- Production browser QA passed for the 9 currently resolvable public hosts in desktop/mobile (`checked: 18`, `failures: []`). The canonical registry domains `alecfest-voliii.com`, `despacholegalastralex.com`, `agent-guide-claude-codex.com`, `pamelabetancourt.com`, and `robertorodriguezrodriguez.com.mx` still returned DNS `ERR_NAME_NOT_RESOLVED` from the local machine and were not counted as app regressions.
 
 ## 2026-06-08 04:09 CT - Runtime alias health assertions
 


### PR DESCRIPTION
## Summary
- Promotes the release audit changelog note from test to main.

## Test Plan
- git diff --check
- npm run test:zoneless-runner