### PR TITLE
fix: harden generic pagination disabled links

### DIFF
--- a/changelog/app/2026-06.md
+++ b/changelog/app/2026-06.md
@@ -1,5 +1,10 @@
 # App Changelog - 2026-06
 
+## 2026-06-24 23:36 CT - Generic pagination disabled state
+
+- Hardened `generic-pagination` so disabled boundary links always receive a component-owned `zlp-pagination-disabled` class, remove pointer cursor utilities, and leave the tab order with `tabindex="-1"`.
+- Added focused coverage for disabled previous/next pagination links so draft-level pagination controls can stay visible without looking clickable when only one page is available.
+
 ## 2026-06-23 00:46 CT - Content hub atomic action wiring
 
 - Extended generic content-hub action support so `runtime.apiActions[].contentHub.action` accepts `upsertTaxonomy`, `queueComment`, and `recordInteraction`.

--- a/src/app/shared/components/generic-pagination/generic-pagination.component.html
+++ b/src/app/shared/components/generic-pagination/generic-pagination.component.html
@@ -8,7 +8,8 @@
     <a
       [href]="previousHref()"
       [class]="previousDisabled() ? disabledLinkClasses() : linkClasses()"
-      [attr.aria-disabled]="previousDisabled()"
+      [attr.aria-disabled]="previousDisabled() ? 'true' : null"
+      [attr.tabindex]="previousDisabled() ? '-1' : null"
       (click)="onNavigate($event, previousHref(), previousDisabled())"
       >{{ previousLabel() }}</a
     >
@@ -27,7 +28,8 @@
     <a
       [href]="nextHref()"
       [class]="nextDisabled() ? disabledLinkClasses() : linkClasses()"
-      [attr.aria-disabled]="nextDisabled()"
+      [attr.aria-disabled]="nextDisabled() ? 'true' : null"
+      [attr.tabindex]="nextDisabled() ? '-1' : null"
       (click)="onNavigate($event, nextHref(), nextDisabled())"
       >{{ nextLabel() }}</a
     >

--- a/src/app/shared/components/generic-pagination/generic-pagination.component.spec.ts
+++ b/src/app/shared/components/generic-pagination/generic-pagination.component.spec.ts
@@ -1,0 +1,43 @@
+import { TestBed } from '@angular/core/testing';
+import { GenericPaginationComponent } from './generic-pagination.component';
+
+describe('GenericPaginationComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [GenericPaginationComponent],
+    }).compileComponents();
+  });
+
+  it('marks disabled boundary links with a visible disabled state', () => {
+    const fixture = TestBed.createComponent(GenericPaginationComponent);
+
+    fixture.componentRef.setInput('config', {
+      collectionPath: 'remote.contentHub.articles.items',
+      hideWhenEmpty: false,
+      hideWhenSinglePage: false,
+      linkClasses: 'pagerLink ank-cursor-pointer',
+      disabledLinkClasses: 'draftDisabledClass',
+      previousLabel: 'Anterior',
+      nextLabel: 'Siguiente',
+      summaryTemplate: 'Pagina {page} de {pageCount}',
+    });
+    fixture.detectChanges();
+
+    const links = Array.from(
+      fixture.nativeElement.querySelectorAll('a')
+    ) as HTMLAnchorElement[];
+    const previous = links.find((link) => link.textContent?.includes('Anterior'));
+    const next = links.find((link) => link.textContent?.includes('Siguiente'));
+
+    expect(previous).toBeTruthy();
+    expect(next).toBeTruthy();
+    expect(previous?.getAttribute('aria-disabled')).toBe('true');
+    expect(next?.getAttribute('aria-disabled')).toBe('true');
+    expect(previous?.getAttribute('tabindex')).toBe('-1');
+    expect(next?.getAttribute('tabindex')).toBe('-1');
+    expect(previous?.className).toContain('pagerLink');
+    expect(previous?.className).toContain('draftDisabledClass');
+    expect(previous?.className).toContain('zlp-pagination-disabled');
+    expect(previous?.className).not.toContain('ank-cursor-pointer');
+  });
+});

--- a/src/app/shared/components/generic-pagination/generic-pagination.component.ts
+++ b/src/app/shared/components/generic-pagination/generic-pagination.component.ts
@@ -27,6 +27,16 @@ import type {
   standalone: true,
   imports: [],
   templateUrl: './generic-pagination.component.html',
+  styles: [`
+    a.zlp-pagination-disabled {
+      cursor: not-allowed;
+      opacity: 0.45;
+    }
+
+    a.zlp-pagination-disabled:hover {
+      cursor: not-allowed;
+    }
+  `],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GenericPaginationComponent {
@@ -112,8 +122,9 @@ export class GenericPaginationComponent {
 
   disabledLinkClasses(): string {
     return this.joinClasses(
-      this.asString(this.config().linkClasses),
-      this.asString(this.config().disabledLinkClasses)
+      this.withoutPointerCursorClasses(this.asString(this.config().linkClasses)),
+      this.asString(this.config().disabledLinkClasses),
+      'zlp-pagination-disabled'
     );
   }
 
@@ -392,6 +403,13 @@ export class GenericPaginationComponent {
     return classes
       .map((entry) => entry.trim())
       .filter(Boolean)
+      .join(' ');
+  }
+
+  private withoutPointerCursorClasses(classes: string): string {
+    return classes
+      .split(/\s+/)
+      .filter((className) => className !== 'ank-cursor-pointer' && className !== 'ank-cur-pointer')
       .join(' ');
   }
 }


### PR DESCRIPTION
## Summary
- Add a component-owned disabled class for generic pagination boundary links.
- Remove pointer cursor utilities from disabled pagination links and set tabindex=-1.
- Add focused Karma coverage for disabled previous/next states.

## Validation
- npm run test -- --watch=false --browsers=ChromeHeadless --include src/app/shared/components/generic-pagination/generic-pagination.component.spec.ts -> TOTAL: 1 SUCCESS
- npm run build -> passed with existing quill-delta CommonJS warning
- git diff --check -> no errors; LF/CRLF warnings only