### PR TITLE
chore: promote tooltip anchor hardening to test

### DIFF
--- a/changelog/app/2026-06.md
+++ b/changelog/app/2026-06.md
@@ -1,5 +1,10 @@
 # App Changelog - 2026-06
 
+## 2026-06-25 01:31 CT - Generic tooltip anchor hardening
+
+- Hardened `generic-tooltip` so draft-authored tooltips can bind to anchors by id after the view is ready, expose an explicit `anchorFor` input for wrapper usage, clean up anchor listeners correctly, and use a real `ViewChild` template for overlay rendering.
+- Verification: focused Karma returned `TOTAL: 92 SUCCESS`, content-hub admin Node tests returned 9 pass, and `npm run build` passed with the existing `quill-delta` CommonJS warning.
+
 ## 2026-06-25 01:19 CT - Generic article admin control polish
 
 - Exposed the existing `generic-tooltip` through `wrapper-orchestrator` with safe draft payload validation for `for` and `content`, so draft-composed controls can attach hover/focus tooltips without app-specific page code.

--- a/src/app/shared/components/generic-tooltip/generic-tooltip.component.spec.ts
+++ b/src/app/shared/components/generic-tooltip/generic-tooltip.component.spec.ts
@@ -26,7 +26,7 @@ describe('GenericTooltipComponent', () => {
   let host: HostCmp;
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HostCmp],
+      imports: [HostCmp, TooltipByIdHostCmp],
     }).compileComponents();
     fixture = TestBed.createComponent(HostCmp);
     host = fixture.componentInstance;
@@ -36,4 +36,25 @@ describe('GenericTooltipComponent', () => {
     const btn = host.btn.nativeElement;
     expect(btn.hasAttribute('aria-describedby')).toBeTrue();
   });
+
+  it('should attach aria-describedby when the anchor is provided by id', () => {
+    const fixtureById = TestBed.createComponent(TooltipByIdHostCmp);
+    fixtureById.detectChanges();
+
+    const btn = fixtureById.nativeElement.querySelector('#button-by-id') as HTMLButtonElement | null;
+
+    expect(btn?.hasAttribute('aria-describedby')).toBeTrue();
+  });
 });
+
+@Component({
+  imports: [GenericTooltipComponent],
+  changeDetection: ChangeDetectionStrategy.Eager,
+  template: `<button id="button-by-id">Buscar</button
+    ><generic-tooltip
+      anchorFor="button-by-id"
+      [content]="'Buscar'"
+      [config]="{ trigger: 'both' }"
+    />`,
+})
+class TooltipByIdHostCmp {}

--- a/src/app/shared/components/generic-tooltip/generic-tooltip.component.ts
+++ b/src/app/shared/components/generic-tooltip/generic-tooltip.component.ts
@@ -2,11 +2,13 @@ import { OverlayRef } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
 import { CommonModule } from '@angular/common';
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   Component,
   ElementRef,
   Input,
   TemplateRef,
+  ViewChild,
   ViewContainerRef,
   computed,
   inject,
@@ -23,18 +25,32 @@ import { TooltipConfig, TooltipPosition } from './generic-tooltip.types';
   styleUrls: ['./generic-tooltip.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class GenericTooltipComponent {
+export class GenericTooltipComponent implements AfterViewInit {
   private readonly pos = inject(OverlayPositioningService);
   private readonly host = inject(ElementRef<HTMLElement>);
   private readonly vcr = inject(ViewContainerRef);
   private overlayRef: OverlayRef | null = null;
-  @Input() for?: HTMLElement | string; // anchor element or id
+  private anchorRef?: HTMLElement | string;
+  private boundAnchor: HTMLElement | null = null;
+
+  @Input('for')
+  set forInput(value: HTMLElement | string | undefined) {
+    this.anchorRef = value;
+    this.bindToAnchor();
+  }
+
+  @Input()
+  set anchorFor(value: HTMLElement | string | undefined) {
+    this.anchorRef = value;
+    this.bindToAnchor();
+  }
 
   readonly config = input<TooltipConfig | null>(null);
   readonly visible = signal(false);
   readonly content = input<string>('');
   @Input() arrow = true;
   @Input() richTemplate?: TemplateRef<unknown>; // optional ng-template for rich content
+  @ViewChild('tooltipTpl', { static: true }) tooltipTpl!: TemplateRef<unknown>;
   private showTimer: ReturnType<typeof setTimeout> | null = null;
   private hideTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -45,9 +61,27 @@ export class GenericTooltipComponent {
   readonly arrowClasses = computed(() => this.config()?.arrowClasses || '');
 
   ngOnInit(): void {
+    this.bindToAnchor();
+  }
+
+  ngAfterViewInit(): void {
+    queueMicrotask(() => this.bindToAnchor());
+  }
+
+  ngOnDestroy(): void {
+    this.clearTimers();
+    this.destroyOverlay();
+    this.unbindAnchor();
+  }
+
+  private bindToAnchor(): void {
+    if (typeof document === 'undefined') return;
     const trigger = this.resolveTrigger();
     const anchor = this.resolveAnchor();
     if (!anchor) return;
+    if (this.boundAnchor === anchor) return;
+
+    this.unbindAnchor();
     if (trigger !== 'focus') {
       anchor.addEventListener('mouseenter', this.scheduleShow);
       anchor.addEventListener('mouseleave', this.scheduleHide);
@@ -57,26 +91,25 @@ export class GenericTooltipComponent {
       anchor.addEventListener('blur', this.scheduleHide);
     }
     anchor.setAttribute('aria-describedby', this.id());
+    this.boundAnchor = anchor;
   }
-  ngOnDestroy(): void {
-    this.clearTimers();
-    this.destroyOverlay();
-    const anchor = this.resolveAnchor();
-    if (anchor) {
-      anchor.removeAttribute('aria-describedby');
-      anchor.removeEventListener('mouseenter', this.scheduleShow);
-      anchor.removeEventListener('mouseleave', this.scheduleHide);
-      anchor.removeEventListener('focus', this.scheduleShow);
-      anchor.removeEventListener('blur', this.scheduleHide);
-    }
+
+  private unbindAnchor(): void {
+    if (!this.boundAnchor) return;
+    this.boundAnchor.removeAttribute('aria-describedby');
+    this.boundAnchor.removeEventListener('mouseenter', this.scheduleShow);
+    this.boundAnchor.removeEventListener('mouseleave', this.scheduleHide);
+    this.boundAnchor.removeEventListener('focus', this.scheduleShow);
+    this.boundAnchor.removeEventListener('blur', this.scheduleHide);
+    this.boundAnchor = null;
   }
 
   private resolveTrigger(): 'hover' | 'focus' | 'both' {
     return this.config()?.trigger || 'both';
   }
   private resolveAnchor(): HTMLElement | null {
-    if (this.for instanceof HTMLElement) return this.for;
-    if (typeof this.for === 'string') return document.getElementById(this.for) as HTMLElement;
+    if (this.anchorRef instanceof HTMLElement) return this.anchorRef;
+    if (typeof this.anchorRef === 'string') return document.getElementById(this.anchorRef) as HTMLElement;
     return this.host.nativeElement.parentElement; // fallback: wrapper pattern
   }
   private scheduleShow = () => {
@@ -170,6 +203,4 @@ export class GenericTooltipComponent {
       this.overlayRef.updatePosition();
     }
   }
-
-  @Input('tooltipTpl') tooltipTpl!: TemplateRef<unknown>; // template reference
 }

--- a/src/app/shared/components/wrapper-orchestrator/wrapper-orchestrator.component.html
+++ b/src/app/shared/components/wrapper-orchestrator/wrapper-orchestrator.component.html
@@ -305,7 +305,7 @@
 </generic-text>
 } @case('tooltip') {
 <generic-tooltip
-  [for]="$any(tooltipConfig(component)).for"
+  [anchorFor]="$any(tooltipConfig(component)).for"
   [content]="tooltipContent(component)"
   [config]="$any(tooltipConfig(component))"
 ></generic-tooltip>


### PR DESCRIPTION
Promotes the generic tooltip anchor hardening to test after /admin/blog/articulos QA found the draft tooltip component rendered but did not bind to its search button anchor.

Validation:
- focused Karma TOTAL: 92 SUCCESS
- node --test tools/tests/content-hub-admin-pages.spec.mjs -> 9 pass
- npm run build passed with existing quill-delta CommonJS warning
- previous draft deploy to testing succeeded for Zoosite article admin UI polish